### PR TITLE
fixes typo in chapter3.md

### DIFF
--- a/docs/chapter3.md
+++ b/docs/chapter3.md
@@ -969,7 +969,7 @@ The Lisp system maintains a symbol table that the function read uses to map betw
 But when a list is read (or built) in two different places, the results are *not* identically the same, even though the corresponding elements may be.
 This is because `read` calls `cons` to build up the list, and each call to `cons` returns a new cons cell.
 [Figure 3.2](#f0015) shows two lists, `x` and `Y`, which are both equal to (`one two`), but which are composed of different cons cells, and hence are not identical.
-[Figure 3.3](#f0020) shows that the expression (`rest x`) does not generate new cons cells, but rather shares structure with `x`, and that the expression (`cons ' zero x`) generates exactly one new cons cell, whose rest is `x`.
+[Figure 3.3](#f0020) shows that the expression (`rest x`) does not generate new cons cells, but rather shares structure with `x`, and that the expression (`cons 'zero x`) generates exactly one new cons cell, whose rest is `x`.
 
 ![Figure 3.2: Equal But Nonidentical Lists](images/chapter3/f03-02.jpg)
 **Figure 3.2: Equal But Nonidentical Lists**


### PR DESCRIPTION
removes errant space between quote and symbol name "zero".