### PR TITLE
Fixing words with accidental code within

### DIFF
--- a/docs/chapter11.md
+++ b/docs/chapter11.md
@@ -1459,7 +1459,7 @@ Modify the program to print "no" only when there are no answers at all, and "no 
 **Exercise  11.5 [h]** At least six books (Abelson and Sussman 1985, [Charniak and McDermott 1985](B9780080571157500285.xhtml#bb0175), Charniak et al.
 1986, [Hennessey 1989](B9780080571157500285.xhtml#bb0530), [Wilensky 1986](B9780080571157500285.xhtml#bb1390), and [Winston and Horn 1988](B9780080571157500285.xhtml#bb1410)) present unification algorithms with a common error.
 They all have problems unifying (`?x ?y a`) with (`?y ?x ?x`).
-Some of these texts assume that `unify`will be called in a context where no variables are shared between the two arguments.
+Some of these texts assume that `unify` will be called in a context where no variables are shared between the two arguments.
 However, they are still suspect to the bug, as the following example points out:
 
 ```lisp

--- a/docs/chapter12.md
+++ b/docs/chapter12.md
@@ -982,7 +982,8 @@ With these definitions in place, we can invoke the compiler automatically just b
 In some implementations of Lisp, when you make a query like `(?
 - (p ?x))`, you may get a warning message like `"function q/1 undefined"` before getting the correct answer.
 The problem is that each function is compiled separately, so warnings detected during the compilation of `p/1` will be printed right away, even if the function `q/1` will be defined later.
-In ANSI Common Lisp there is a way to delay the printing of warnings until a series of compilations are done: wrap the compilation with the macro `with-compi`l`ation-unit.` Even if your implementation does not provide this macro, it may provide the same functionality under a different name.
+In ANSI Common Lisp there is a way to delay the printing of warnings until a series of compilations are done: wrap the compilation with the macro `with-compilation-unit`.
+Even if your implementation does not provide this macro, it may provide the same functionality under a different name.
 Find out if `with-compilation-unit` is already defined in your implementation, or if it can be defined.
 
 ## 12.7 Benchmarking the Compiler

--- a/docs/chapter15.md
+++ b/docs/chapter15.md
@@ -615,7 +615,7 @@ a+b3=b3+3ab2+3a2b+a3
 ![si5_e](images/chapter15/si5_e.gif)
 
 We can use this theorem to compute a power of a polynomial all at once, instead of computing it by repeated multiplication or squaring.
-Of course, a polynomial will in general be a sum of more than two components, so we have to decid`e` how to split it into the *a* and *b* pieces.
+Of course, a polynomial will in general be a sum of more than two components, so we have to decide how to split it into the *a* and *b* pieces.
 There are two obvious ways: either eut the polynomial in half, so that *a* and *b* will be of equal size, or split off one component at a time.
 Fateman shows that the latter method is more efficient in most cases.
 In other words, a polynomial k1xn+k2xn-1+k3xn-2+... !!!(span) {:.hiddenClass} ![si6_e](images/chapter15/si6_e.gif) will be treated as the sum *a + b* where *a*=  *k*1*xn* and *b* is the rest of the polynomial.

--- a/docs/chapter17.md
+++ b/docs/chapter17.md
@@ -479,7 +479,7 @@ The initial diagram is:
  E/6 L: EC=[RL+L-R] EB=[LRR+L-]
  F/6 L: FD=[RL+L-R] FC=[LRR+L-]
  G/6 L: GB=[RL+L-R] GD=[LRR+L-]
-For 29,160 interpr`e`tations.
+For 29,160 interpretations.
 After constraint propagation the diagram is:
  A/1 Y: AB=[+] AC=[+] AD=[+]
  B/2 W: BG=[L-] BE=[R-] BA=[++]
@@ -488,7 +488,7 @@ After constraint propagation the diagram is:
  E/3 L: EC=[R-R] EB=[LL-]
  F/3 L: FD=[R-R] FC=[LL-]
  G/3 L: GB=[R-R] GD=[LL-]
-For 216 interpr`e`tations.
+For 216 interpretations.
 There are four solutions:
 Diagram:
   A/1 Y: AB=[+] AC=[+] AD=[+]
@@ -560,7 +560,7 @@ The initial diagram is:
  E/6 L: EC=[RL+L-R] EB[LRR+L-]
  F/6 L: FD=[RL+L-R] FC=[LRR+L-]
  G/1 L: GB=[R] GD=[-]
-For 4,860 interpr`e`tations.
+For 4,860 interpretations.
 After constraint propagation the diagram is:
  A/1 Y: AB=[+] AC=[+] AD=[+]
  B/l W: BG=[L] BE=[R] BA=[+]
@@ -619,7 +619,7 @@ The initial diagram is:
  K/1 W: KM=[-] KL=[-] KJ=[+]
  L/6 L: LH=[RL+L-R] LK=[LRR+L-]
  M/6 L: MK=[RL+L-R] MI=[LRR+L-]
-For 32.805.000 interpr`e`tations.
+For 32.805.000 interpretations.
 After constraint propagation the diagram is
   A/1 Y: AB=[+] AC=[+] AD=[+]
   B/2 W: BG=[L-] BE=[R-] BA=[++]
@@ -667,7 +667,7 @@ The initial diagram is:
  J/6 L: JK=[RL+L-R] JB=[LRR+L-]
  K/3 W: KJ=[L-+] KI=[R-+] KF=[++-]
  L/3 W: LH=[L-+] LG=[R-+] LC=[++-]
-For 544,195.584 interpr`e`tations.
+For 544,195.584 interpretations.
 After constraint propagation the diagram is:
  A/5 L: AB=[RL+-R] AG=[LRRL-]
  B/5 L: BJ=[RLL-R] BA=[LR+L-]
@@ -681,8 +681,8 @@ After constraint propagation the diagram is:
  J/4 L: JK=[R+-R] JB=[LRL-]
  K/3 W: KJ=[L-+] KI=[R-+] KF=[++-]
  L/3 W: LH=[L-+] LG=[R-+] LC=[++-]
-For 2,073,600 interpr`e`tations.
-There are z`e`ro solutions:
+For 2,073,600 interpretations.
+There are zero solutions:
 ```
 
 Now we try a more complex diagram:

--- a/docs/chapter21.md
+++ b/docs/chapter21.md
@@ -1021,7 +1021,7 @@ Here is a fairly complete list of prepositions:
 ## 21.12 Supporting the Lexicon
 
 This section describes the implementation of the macros `word`, `verb, noun`, and `abbrev.` Abbreviations are stored in a hash table.
-The macro `abbr`e`v` and the functions `get-abbrev` and `clear-abbrevs` define the interface.
+The macro `abbrev` and the functions `get-abbrev` and `clear-abbrevs` define the interface.
 We will see how to expand abbreviations later.
 
 ```lisp

--- a/docs/chapter24.md
+++ b/docs/chapter24.md
@@ -678,7 +678,7 @@ The clauses covered here are:
 Here is an example of `when`:
 
 ```lisp
-> (loop for`x `from 1 to 10
+> (loop for x from 1 to 10
      when (oddp x)
          collect x
      else collect (- x))

--- a/docs/chapter25.md
+++ b/docs/chapter25.md
@@ -145,7 +145,7 @@ Its value is the old definition of `score-fn`.
 
 **Remedy:** Re-evaluate the definition of *`scorer`*.
 It is unfortunate, but this problem encourages many programmers to use symbols where they really mean functions.
-Symbols will be coerced to the global function they name when passed to `funcall`or `apply`, but this can be the source of another error.
+Symbols will be coerced to the global function they name when passed to `funcall` or `apply`, but this can be the source of another error.
 In the following example, the symbol `local - fn` will not refer to the locally bound function.
 One needs to use `#'local - fn` to refer to it.
 

--- a/docs/chapter9.md
+++ b/docs/chapter9.md
@@ -1578,7 +1578,8 @@ We need to preserve the order of the rules, so only certain optimizations are po
 We'll use the `simp-fn` facility to install the one big function for each operator.
 
 The function `compile-rule-set` takes an operator, finds all the rules for that operator, and compiles each rule individually.
-(It uses`compile-indexed-rule` rather than `compile-rule`, because it assumes we have already done the indexing for the main operator.) After each rule has been compiled, they are combined with `combine-rules`, which merges similar parts of rules and concatenates the different parts.
+(It uses `compile-indexed-rule` rather than `compile-rule`, because it assumes we have already done the indexing for the main operator.)
+After each rule has been compiled, they are combined with `combine-rules`, which merges similar parts of rules and concatenates the different parts.
 The result is wrapped in a `lambda` expression and compiled as the final simplification function for the operator.
 
 ```lisp


### PR DESCRIPTION
Words like "decid`e`"