### PR TITLE
Fixing errors caught while skimming

### DIFF
--- a/docs/chapter1.md
+++ b/docs/chapter1.md
@@ -423,11 +423,11 @@ This is a much easier task than hunting through a large program and changing the
   "Select the first name from a name represented as a list."
   (first name))
 
-> p => (JOHN Q PUBLIC)`
+> p => (JOHN Q PUBLIC)
 
-> (first-name p) => JOHN`
+> (first-name p) => JOHN
 
-> (first-name '(Wilma Flintstone)) => WILMA`
+> (first-name '(Wilma Flintstone)) => WILMA
 
 > (setf names '((John Q Public) (Malcolm X)
               (Admiral Grace Murray Hopper) (Spot) 

--- a/docs/chapter1.md
+++ b/docs/chapter1.md
@@ -1203,7 +1203,7 @@ This list of symbols is not a legal Lisp assignment statement, but it is a Lisp 
 
 <a id="fn01-2"></a><sup>[2](#tfn01-2)</sup>
 The variable `*print-case*` controls how symbols will be printed.
-By default, the value of this variable is :`upcase`, but it can be changed to :`downcase` or `:capitalize`.
+By default, the value of this variable is `:upcase`, but it can be changed to `:downcase` or `:capitalize`.
 
 <a id="fn01-3"></a><sup>[3](#tfn01-3)</sup>
 Later we will see what happens when the second argument is not a list.

--- a/docs/chapter1.md
+++ b/docs/chapter1.md
@@ -72,7 +72,7 @@ If we want, we can give + more than two arguments, and it will still add them al
 > (+ 1 2 3 4 5 6 7 8 9 10) => 55
 ```
 
-This time we try (9000 + 900 + 90  + 9) - (5000 + 500 + 50 + 5):
+This time we try (9000 + 900 + 90 + 9) - (5000 + 500 + 50 + 5):
 
 ```lisp
 > (- (+ 9000 900 90 9) (+ 5000 500 50 5)) => 4444
@@ -151,9 +151,9 @@ Here are some examples:
 
 > 2 => 2
 
-> '(+  2 2) => (+  2 2)
+> '(+ 2 2) => (+ 2 2)
 
-> (+  2 2) 4
+> (+ 2 2) 4
 
 > John => *Error: JOHN is not a bound variable*
 
@@ -236,8 +236,8 @@ First, Lisp's syntactic forms are always lists in which the first element is one
 Second, special forms are expressions that return a value.
 This is in contrast to statements in most languages, which have an effect but do not return a value.
 
-In evaluating an to expression *(ed note: ???)* like `(setf x (+  1 2)`), we set the variable named by the symbol `x` to the value of `(+  1 2)`, which is `3`.
-If `setf` were a normal function, we would evaluate both the symbol `x` and the expression `(+  1 2)` and do something with these two values, which is not what we want at all.
+In evaluating an expression like `(setf x (+ 1 2)`), we set the variable named by the symbol `x` to the value of `(+ 1 2)`, which is `3`.
+If `setf` were a normal function, we would evaluate both the symbol `x` and the expression `(+ 1 2)` and do something with these two values, which is not what we want at all.
 `setf` is called a special form because it does something special: if it did not exist, it would be impossible to write a function that assigns a value to a variable.
 The philosophy of Lisp is to provide a small number of special forms to do the things that could not otherwise be done, and then to expect the user to write everything else as functions.
 
@@ -246,7 +246,7 @@ In the book *Common LISPcraft,* Wilensky resolves the ambiguity by calling `setf
 This terminology implies that `setf` is just another function, but a special one in that its first argument is not evaluated.
 Such a view made sense in the days when Lisp was primarily an interpreted language.
 The modern view is that `setf` should not be considered some kind of abnormal function but rather a marker of special syntax that will be handled specially by the compiler.
-Thus, the special form `(setf x (+  2 1))` should be considered the equivalent of `x = 2 + 1` in `C`.
+Thus, the special form `(setf x (+ 2 1))` should be considered the equivalent of `x = 2 + 1` in `C`.
 When there is risk of confusion, we will call `setf` a *special form operator* and `(setf x 3)` a *special form expression.*
 
 It turns out that the quote mark is just an abbreviation for another special form.
@@ -715,7 +715,7 @@ The alternate definition of `mappend` shown in the following doesn't make use of
 > (funcall #' + '(2 3)) => *Error: (2 3) is not a number.*
 ```
 
-These are equivalent to `(+  2 3), (+ 2 3)`,and`(+ '(2 3))`, respectively.
+These are equivalent to `(+ 2 3), (+ 2 3)`,and`(+ '(2 3))`, respectively.
 
 So far, every function we have used has been either predefined in Common Lisp or introduced with a `defun`, which pairs a function with a name.
 It is also possible to introduce a function without giving it a name, using the special syntax `lambda`.
@@ -828,14 +828,14 @@ Similarly, the notation `#'f` is an abbreviation for the special form expression
 
 defun twice (x) (+ x x)) => TWICE
 
-(if (=  2 3) (error) (+  5 6)) => 11
+(if (= 2 3) (error) (+ 5 6)) => 11
 ```
 
 *   A *function application* is evaluated by first evaluating the arguments (the rest of the list) and then finding the function named by the first element of the list and applying it to the list of evaluated arguments.
 
 ```lisp
-(+  2 3) => 5
-(- (+  90 9) (+  50 5 (length '(Pat Kim)))) => 42
+(+ 2 3) => 5
+(- (+ 90 9) (+ 50 5 (length '(Pat Kim)))) => 42
 ```
 
 Note that if `'(Pat Kim)` did not have the quote, it would betreated as a function application of the function `pat` to the value of the variable `kim.`

--- a/docs/chapter10.md
+++ b/docs/chapter10.md
@@ -809,7 +809,8 @@ Here is a definition for a version of `remove` that uses `reuse-cons`:
 Of course, `reuse-cons` only works when you have candidate cons cells around.
 That is, (`reuse-cons a b c`) only saves space when `c` is (or might be) equal to (`cons a b`).
 For some applications, it is useful to have a version of `cons` that returns a unique cons cell without needing `c` as a hint.
-We will call this version `ucons` for "unique cons." `ucons` maintains a double hash table: `*uniq - cons - table*` is a hash table whose keys are the `cars` of cons cells.
+We will call this version `ucons` for "unique cons."
+`ucons` maintains a double hash table: `*uniq-cons-table*` is a hash table whose keys are the `cars` of cons cells.
 The value for each `car` is another hash table whose keys are the `cdrs` of cons cells.
 The value of each `cdr` in this second table is the original cons cell.
 So two different cons cells with the same `car` and `cdr` will retrieve the same value.
@@ -888,7 +889,7 @@ An `eq` hash table for lists is almost as good as a property list on symbols.
 ### Avoid Consing: Multiple Values
 
 Parameters and multiple values can also be used to pass around values, rather than building up lists.
-For example, instead of :
+For example, instead of:
 
 ```lisp
 (defstruct point "A point in 3-D cartesian space." x y z)
@@ -1335,7 +1336,7 @@ Here is a possible macroexpansion:
  'person)
 ```
 
-**Exercise 10.2 [m]** We can use the :`type` option to `defstruct` to define structures implemented as lists.
+**Exercise 10.2 [m]** We can use the `:type` option to `defstruct` to define structures implemented as lists.
 However, often we have a two-field structure that we would like to implement as a cons cell rather than a two-element list, thereby cutting storage in half.
 Since `defstruct` does not allow this, define a new macro that does.
 

--- a/docs/chapter11.md
+++ b/docs/chapter11.md
@@ -1476,7 +1476,7 @@ This marker would be checked by `variable-p`.
 Variable names can be stored in a hash table that is cleared before each query.
 Implement this representation for variables and compare it to the structure representation.
 
-**Exercise  11.7 [m]** Consider the following alternative implementation for anonymous variables: Leave the macros <- and ?- alone, so that anonymous variables are allowed in assertions and queries.
+**Exercise 11.7 [m]** Consider the following alternative implementation for anonymous variables: Leave the macros `<-` and `?-` alone, so that anonymous variables are allowed in assertions and queries.
 Instead, change `unify` so that it lets anything match against an anonymous variable:
 
 ```lisp

--- a/docs/chapter11.md
+++ b/docs/chapter11.md
@@ -874,7 +874,7 @@ Finally, the Lisp predicate `continue-p` asks the user if he or she wants to see
 This version works just as well as the previous version on finite problems.
 The only difference is that the user, not the system, types the semicolons.
 The advantage is that we can now use the system on infinite problems as well.
-First, we'll ask what lists 2 is a member of :
+First, we'll ask what lists 2 is a member of:
 
 ```lisp
 > (?- (member 2 ?list))
@@ -1459,7 +1459,7 @@ It is interesting to compare different implementations of the same algorithm.
 It turns out there are more similarities than differences.
 This indicates two things: (1) there is a generally agreed-upon style for writing these functions, and (2) good programmers sometimes take advantage of opportunities to look at other's code.
 
-The question is : Can you give an informal proof of the correctness of the algorithm presented in this chapter?
+The question is: Can you give an informal proof of the correctness of the algorithm presented in this chapter?
 Start by making a clear statement of the specification.
 Apply that to the other algorithms, and show where they go wrong.
 Then see if you can prove that the `unify` function in this chapter is correct.

--- a/docs/chapter11.md
+++ b/docs/chapter11.md
@@ -1101,30 +1101,30 @@ Consider constraint 2, "The Englishman lives in the `red` house." This is interp
 
 ```lisp
 (<- (zebra ?h ?w ?z)
-  ;; Each house is of the form:
-  ;; (house nationality pet cigarette drink house-color)
-  (= ?h ((house norwegian ? ? ? ?)                                    ;1,10
-                ?
-                (house ? ? ? milk ?) ? ?))                                  ; 9
-  (member (house englishman ? ? ? red) ?h)                    ; 2
-  (member (house spaniard dog ? ? ?) ?h)                        ; 3
-  (member (house ? ? ? coffee green) ?h)                        ; 4
-  (member (house ukrainian ? ? tea ?) ?h)                      ; 5
-  (iright (house ? ? ? ? ivory)                                          ; 6
-                  (house 1111 green) ?h)
-  (member (house ? snails winston ? ?) ?h)                    ; 7
-  (member (house ? ? kools ? yellow) ?h)                        ; 8
-  (nextto (house ? ? chesterfield ? ?)                            ;11
-                  (house ? fox ? ? ?) ?h)
-  (nextto (house ? ? kools ? ?)                                          ;12
-                  (house ? horse ? ? ?) ?h)
-  (member (house ? ? luckystrike orange-juice ?) ?h);13
-  (member (house japanese ? parliaments ? ?) ?h)        ;14
-  (nextto (house norwegian ? ? ? ?)                                  ;15
-                  (house ? ? ? ? blue) ?h)
-  ;; Now for the questions:
-  (member (house ?w ? ? water ?) ?h)                                ;Q1
-  (member (house ?z zebra ? ? ?) ?h))                              ;Q2
+ ;; Each house is of the form:
+ ;; (house nationality pet cigarette drink house-color)
+ (= ?h ((house norwegian ? ? ? ?)                  ;1,10
+        ?
+        (house ? ? ? milk ?) ? ?))                 ; 9
+ (member (house englishman ? ? ? red) ?h)          ; 2
+ (member (house spaniard dog ? ? ?) ?h)            ; 3
+ (member (house ? ? ? coffee green) ?h)            ; 4
+ (member (house ukrainian ? ? tea ?) ?h)           ; 5
+ (iright (house ? ? ? ? ivory)                     ; 6
+         (house 1111 green) ?h)
+ (member (house ? snails winston ? ?) ?h)          ; 7
+ (member (house ? ? kools ? yellow) ?h)            ; 8
+ (nextto (house ? ? chesterfield ? ?)              ;11
+         (house ? fox ? ? ?) ?h)
+ (nextto (house ? ? kools ? ?)                     ;12
+         (house ? horse ? ? ?) ?h)
+ (member (house ? ? luckystrike orange-juice ?) ?h);13
+ (member (house japanese ? parliaments ? ?) ?h)    ;14
+ (nextto (house norwegian ? ? ? ?)                 ;15
+         (house ? ? ? ? blue) ?h)
+ ;; Now for the questions:
+ (member (house ?w ? ? water ?) ?h)                ;Q1
+ (member (house ?z zebra ? ? ?) ?h))               ;Q2
 ```
 
 Here's the query and solution to the puzzle:
@@ -1543,22 +1543,25 @@ The former takes the child first; the latter takes the husband first.
 Given these primitives, we can make the following definitions:
 
 ```lisp
-(<- (father ?f ?e)    (male ?f) (parent ?f ?c))
-(<- (mother ?m ?c)    (female ?m) (parent ?m c))
+(<- (father ?f ?e)   (male ?f) (parent ?f ?c))
+(<- (mother ?m ?c)   (female ?m) (parent ?m c))
 (<- (son ?s ?p)      (male ?s) (parent ?p ?s))
-(<- (daughter ?s ?p)    (male ?s) (parent ?p ?s))
-(<- (grandfather ?g ?c) (father ?g ?p) (parent ?p ?c))
-(<- (grandmother ?g ?c) (mother ?g ?p) (parent ?p ?c))
-(<- (grandson ?gs ?gp) (son ?gs ?p) (parent ?gp ?p))
+(<- (daughter ?s ?p) (male ?s) (parent ?p ?s))
+
+(<- (grandfather ?g ?c)     (father ?g ?p) (parent ?p ?c))
+(<- (grandmother ?g ?c)     (mother ?g ?p) (parent ?p ?c))
+(<- (grandson ?gs ?gp)      (son ?gs ?p) (parent ?gp ?p))
 (<- (granddaughter ?gd ?gp) (daughter ?gd ?p) (parent ?gp ?p))
-(<- (parent ?p ?c)    (child ?c ?p))
-(<- (wife ?w ?h)      (married ?h ?w))
-(<- (husband ?h ?w)    (married ?h ?w))
-(<- (sibling ?x ?y)    (parent ?p ?x) (parent ?p ?y))
-(<- (brother ?b ?x)      (male ?b) (sibling ?b ?x))
-(<- (sister ?s ?x)        (female ?s) (sibling ?s ?x))
-(<- (uncle ?u ?n)        (brother ?u ?p) (parent ?p ?n))
-(<- (aunt ?a ?n)        (sister ?a ?p) (parent ?p ?n  ))
+
+(<- (parent ?p ?c)   (child ?c ?p))
+(<- (wife ?w ?h)     (married ?h ?w))
+(<- (husband ?h ?w)  (married ?h ?w))
+
+(<- (sibling ?x ?y)  (parent ?p ?x) (parent ?p ?y))
+(<- (brother ?b ?x)  (male ?b) (sibling ?b ?x))
+(<- (sister ?s ?x)   (female ?s) (sibling ?s ?x))
+(<- (uncle ?u ?n)    (brother ?u ?p) (parent ?p ?n))
+(<- (aunt ?a ?n)     (sister ?a ?p) (parent ?p ?n  ))
 ```
 
 Note that there is no way in Prolog to express a *true* definition.

--- a/docs/chapter12.md
+++ b/docs/chapter12.md
@@ -1684,7 +1684,7 @@ should be compiled as if it were:
 
 *   `atomic/1` True if the argument is a number or symbol (like Lisp's `atom`).
 
-*   <,>,=<,>= Arithmetic comparison; succeeds when the arguments are both instantiated to numbers and the comparison is true.
+*   `<`, `>`, `=<`, `>=` Arithmetic comparison; succeeds when the arguments are both instantiated to numbers and the comparison is true.
 
 *   `listing/0` Print out the clauses for all defined predicates.
 

--- a/docs/chapter12.md
+++ b/docs/chapter12.md
@@ -530,7 +530,7 @@ Now `member` compiles into this:
 ## 12.4 Improving the Compilation of Unification
 
 Now we turn to the improvement of `compile-unify`.
-Recall that we want to elimina te certain calls to `unify!` so that, for example, the first clause of `member:`
+Recall that we want to eliminate certain calls to `unify!` so that, for example, the first clause of `member:`
 
 ```lisp
 (<- (member ?item (?item . ?rest)))
@@ -581,7 +581,7 @@ In addition, unification of two cons cells can be broken into components at comp
 We can even do some occurs checking at compile time: `(= ?x (f ?x))` should fail.
 
 The following table lists these improvements, along with a breakdown for the cases of unifying a bound `(?arg1)` or unbound `(?x)` variable agains another expression.
-The first column is the unification call, the second is the generated code, and the third is the bindings that will be added as a resuit of the call:
+The first column is the unification call, the second is the generated code, and the third is the bindings that will be added as a result of the call:
 
 |      | Unification         | Code                    | Bindings            |
 |------|---------------------|-------------------------|---------------------|
@@ -1237,7 +1237,7 @@ The set {*a*, *b*} is the same as the set {*b*, *a*}.
 Here is an implementation of `bagof:`
 
 ```lisp
-(defun bagof/3 (exp goal resuit cont)
+(defun bagof/3 (exp goal result cont)
  "Find all solutions to GOAL, and for each solution,
  collect the value of EXP into the list RESULT."
  ;; Ex: Assume (p 1) (p 2) (p 3). Then:
@@ -1246,7 +1246,7 @@ Here is an implementation of `bagof:`
  (call/1 goal #'(lambda ()
    (push (deref-copy exp) answers)))
  (if (and (not (null answers))
-  (unify! resuit (nreverse answers)))
+  (unify! result (nreverse answers)))
  (funcall cont))))
  (defun deref-copy (exp)
  "Copy the expression, replacing variables with new ones.
@@ -1280,7 +1280,7 @@ No.
 Those who are disappointed with a bag containing multiple versions of the same answer may prefer the primitive `setof`, which does the same computation as `bagof` but then discards the duplicates.
 
 ```lisp
-(defun setof/3 (exp goal resuit cont)
+(defun setof/3 (exp goal result cont)
  "Find all unique solutions to GOAL, and for each solution,
  collect the value of EXP into the list RESULT."
  ;; Ex: Assume (p 1) (p 2) (p 3). Then:
@@ -1289,7 +1289,7 @@ Those who are disappointed with a bag containing multiple versions of the same a
  (call/1 goal #'(lambda ()
    (push (deref-copy exp) answers)))
  (if (and (not (null answers))
-  (unify! resuit (delete-duplicates
+  (unify! result (delete-duplicates
     answers
     :test #'deref-equal)))
  (funcall cont))))
@@ -1510,7 +1510,7 @@ The predicate repeat is defined with the following two clauses:
 (<- (repeat) (repeat))
 ```
 
-An alterna te definition as a primitive is:
+An alternate definition as a primitive is:
 
 ```lisp
 (defun repeat/0 (cont)

--- a/docs/chapter12.md
+++ b/docs/chapter12.md
@@ -1797,7 +1797,7 @@ The macro for `or` is trickier:
                 bindings)))))))))
 ```
 
-**Answer 12.11**`true/0` is `funcall` : when a goal succeeds, we call the continuation, `fail/0` is `ignore`: when a goal fails, we ignore the continuation.
+**Answer 12.11** `true/0` is `funcall`: when a goal succeeds, we call the continuation, `fail/0` is `ignore`: when a goal fails, we ignore the continuation.
 We could also define compiler macros for these primitives:
 
 ```lisp

--- a/docs/chapter13.md
+++ b/docs/chapter13.md
@@ -956,7 +956,7 @@ But it was possible to combine methods in other ways as well.
 For example, consider the `inside-width` method, which returns the width in pixels of the usuable portion of a window.
 A programmer could specify that the combined method for `inside-width` was to be computed by calling all applicable methods and summing them.
 Then an `inside-width` method for the `basic-window` flavor would be defined to return the width of the full window, and each mix-in would have a simple method to say how much of the width it consumed.
-For example, if borders are 8 pixels wide and scroll bars are 12 pixels wide, then the `inside-width` method for `border-mixin` returns `-8` and `scroll-bar-mixin` returns `-  12`.
+For example, if borders are 8 pixels wide and scroll bars are 12 pixels wide, then the `inside-width` method for `border-mixin` returns `-8` and `scroll-bar-mixin` returns `-12`.
 Then any window, no matter how many mix-ins it is composed of, automatically computes the proper inside width.
 
 In 1981, Symbolics came out with a more efficient implementation of Flavors.

--- a/docs/chapter13.md
+++ b/docs/chapter13.md
@@ -538,12 +538,13 @@ It could be defined as follows using a new feature of CLOS, `:before` and `:afte
   (audit-trail acct)))
 ```
 
-Now a call to `withdraw` with a `audited-account` as the first argument yields three applicable methods: the primary method from `account` and the :`before` and :`after` methods.
+Now a call to `withdraw` with a `audited-account` as the first argument yields three applicable methods: the primary method from `account` and the `:before` and `:after` methods.
 In general, there might be several of each kind of method.
-In that case, all the :`before` methods are called in order, most specific first.
+In that case, all the `:before` methods are called in order, most specific first.
 Then the most specific primary method is called.
-It may choose to invoke `cal1-next-method` to get at the other methods.
-(It is an error for a :`before` or :`after` method to use `call-next-method.)` Finally, all the :`after` methods are called, least specific first.
+It may choose to invoke `call-next-method` to get at the other methods.
+(It is an error for a `:before` or `:after` method to use `call-next-method.)`
+Finally, all the `:after` methods are called, least specific first.
 
 The values from the `:before` and `:after` methods are ignored, and the value from the primary method is returned.
 Here is an example:
@@ -950,7 +951,7 @@ These mix-in flavors were used only to define other flavors.
 Just as you couldn't go into Steve's and order "crushed Heath bars, hold the ice cream," there was a mechanism to prohibit instantiation of mix-ins.
 
 A complicated repetoire of *method combinations* was developed.
-The default method combination on Flavors was similar to CLOS: first do all the :`before` methods, then the most specific primary method, then the `:after` methods.
+The default method combination on Flavors was similar to CLOS: first do all the `:before` methods, then the most specific primary method, then the `:after` methods.
 But it was possible to combine methods in other ways as well.
 For example, consider the `inside-width` method, which returns the width in pixels of the usuable portion of a window.
 A programmer could specify that the combined method for `inside-width` was to be computed by calling all applicable methods and summing them.

--- a/docs/chapter14.md
+++ b/docs/chapter14.md
@@ -17,7 +17,7 @@ In particular, a lot of work was concerned with *theorem proving:* stating a pro
 The implicit assumption was that the power resided in the inference mechanism-if we could just find the right search technique, then all our problems would be solved, and all our theorems would be proved.
 
 Starting in the 1970s, this began to change.
-The theorem-proving approach falled to live up to its promise.
+The theorem-proving approach failed to live up to its promise.
 AI workers slowly began to realize that they were not going to solve NP-hard problems by coming up with a clever inference algorithm.
 The general inferencing mechanisms that worked on toy examples just did not scale up when the problem size went into the thousands (or sometimes even into the dozens).
 
@@ -28,7 +28,7 @@ In this view it doesn't matter very much if MYCIN uses forward- or backward-chai
 What matters crucially is that we know pseudomonas is a gram-negative, rod-shaped organism that can infect patients with compromised immune systems.
 In other words, the key problem is acquiring and representing knowledge.
 
-While the expert system approach had some successes, it also had fallures, and researchers were interested in learning the limits of this new technology and understanding exactly how it works.
+While the expert system approach had some successes, it also had failures, and researchers were interested in learning the limits of this new technology and understanding exactly how it works.
 Many found it troublesome that the meaning of the knowledge used in some systems was never clearly defined.
 For example, does the assertion `(color apple red)` mean that a particular apple is red, that all apples are red, or that some/most apples are red?
 The field of *knowledge representation* concentrated on providing clear semantics for such representations, as well as providing algorithms for manipulating the knowledge.
@@ -404,7 +404,7 @@ One approach would be this:
 
 These rules say that 0 is an integer, and any *n* is an integer if *n* + 1 is, and *n* + 1 is if *n* is.
 While these rules are correct in a logical sense, they don't work as a Prolog program.
-Asking `(integer *x*)` will resuit in an endless series of ever-increasing queries: `(integer (1  + *x*)), (integer (1  + (1  + *x*)))`, and so on.
+Asking `(integer *x*)` will result in an endless series of ever-increasing queries: `(integer (1  + *x*)), (integer (1  + (1  + *x*)))`, and so on.
 Each goal is different, so no check can stop the recursion.
 
 The occurs check may or may not introduce problems into Prolog, depending on your interpretation of infinite trees.
@@ -545,7 +545,7 @@ In general, all the keys indexed under variables along the path must be consider
 
 The retrieval mechanism can overretrieve.
 Given the query `(p a (f ?x))`, the atom `p` will again retrieve all six keys, the atom a retrieves 1, 2, 3, and 6, and f again retrieves 5, 6, and 3.
-So `f` retrieves the shortest list, and hence it will be used to determine the final resuit.
+So `f` retrieves the shortest list, and hence it will be used to determine the final result.
 But key 5 is `(p b (f c))`, which does not match the query `(pa (f?x))`.
 
 We could eliminate this problem by intersecting all the lists instead of just taking the shortest list.
@@ -808,7 +808,7 @@ If the match is true, it calls the supplied function with the binding list that 
 ```
 
 There are many ways to use this retriever.
-The function `retrieve` returns a list of the matching binding lists, and `retrieve-matches` substitutes each binding list into the original query so that the resuit is a list of expressions that unify with the query.
+The function `retrieve` returns a list of the matching binding lists, and `retrieve-matches` substitutes each binding list into the original query so that the result is a list of expressions that unify with the query.
 
 ```lisp
 (defun retrieve (query)
@@ -862,7 +862,7 @@ The macro `query-bind` is provided as a nice interface to `mapc-retrieve`.
 The macro takes as arguments a list of variables to bind, a query, and one or more forms to apply to each retrieved answer.
 Within this list of forms, the variables will be bound to the values that satisfy the query.
 The syntax was chosen to be the same as `multiple-value-bind`.
-Here we see a typical use of `query-bind`, its resuit, and its macro-expansion:
+Here we see a typical use of `query-bind`, its result, and its macro-expansion:
 
 ```lisp
 > (query-bind (?x ?fn) '(p ?x (?fn c))
@@ -1615,7 +1615,7 @@ The new function `nalist-push` adds a value to an nalist, either by inserting th
 ```
 
 In the following, `fetch` is used on the same data base created by `test-index`, indexed under the world `W0`.
-This time the resuit is a list-of-lists of world/values a-lists.
+This time the result is a list-of-lists of world/values a-lists.
 The count, 3, is the same as before.
 
 ```lisp

--- a/docs/chapter14.md
+++ b/docs/chapter14.md
@@ -292,7 +292,7 @@ In other words, everyone likes some person, but not necessarily the same person.
 In the previous section we saw that Prolog has traded some expressiveness for efficiency.
 This section explores the limits of predicate calculus's expressiveness.
 
-Suppose we want to assert that lions, tigers, and bears are kinds of animais.
+Suppose we want to assert that lions, tigers, and bears are kinds of animals.
 In predicate calculus or in Prolog we could write an implication for each case:
 
 ```lisp
@@ -302,7 +302,7 @@ In predicate calculus or in Prolog we could write an implication for each case:
 ```
 
 These implications allow us to prove that any known lion, tiger, or bear is in fact an animal.
-However, they do not allow us to answer the question "What kinds of animais are there?" It is not hard to imagine extending Prolog so that the query
+However, they do not allow us to answer the question "What kinds of animals are there?" It is not hard to imagine extending Prolog so that the query
 
 ```lisp
 (?- (<- (animal ?x) ?proposition))
@@ -331,7 +331,7 @@ But how well does predicate calculus fare in a world of continuous substances?
 Consider a body of water consisting of an indefinite number of subconstituents that are all water, with some of the water evaporating into the air and rising to form clouds.
 It is not at all obvious how to define the individuals here.
 However, Patrick Hayes has shown that when the proper choices are made, predicate calculus can describe this kind of situation quite well.
-The detalls are in Hayes 1985.
+The details are in Hayes 1985.
 
 The need to define categories is a more difficult problem.
 Predicate calculus works very well for crisp, mathematical categories: a; is a triangle if and only if *x* is a polygon with three sides.
@@ -370,7 +370,7 @@ No.
 
 We get the expected conclusions, but they are deduced repeatedly, because the commutative clause for siblings is applied over and over again.
 This is annoying, but not critical.
-Far worseis when we ask `(?- (sibling fred ?x))`.
+Far worse is when we ask `(?- (sibling fred ?x))`.
 This query loops forever.
 Happily, this particular type of example has an easy fix: just introduce two predicates, one for data-base level facts, and one at the level of axioms and queries:
 
@@ -489,7 +489,7 @@ We don't know what typical facts will look like, nor typical queries.
 Therefore, we will design a fairly abstract tool, forgetting for the moment that it will be used to index Prolog facts.
 
 We will address the problem of a discrimination tree where both the keys and queries are predicate structures with wild cards.
-A wild card is a variable, but with the understanding thatthere is no variable binding; each instance of a variable can match anything.
+A wild card is a variable, but with the understanding that there is no variable binding; each instance of a variable can match anything.
 A predicate structure is a list whose first element is a nonvariable symbol.
 The discrimination tree supports three operations:
 
@@ -517,7 +517,7 @@ This should match keys 2, 3, and 4.
 How could we efficiently arrive at this set?
 One idea is to list the key/value pairs under every atom that they contain.
 Thus, all six would be listed under the atom `p`, while 2, 4, and 5 would be listed under the atom c.
-A unification check could elimina te 5, but we still would be missing 3.
+A unification check could eliminate 5, but we still would be missing 3.
 Key 3 (and every key with a variable in it) could potentially contain the atom `c`.
 So to get the right answers under this approach, we will need to index every key that contains a variable under every atom-not an appealing situation.
 
@@ -976,7 +976,7 @@ However, it only proceeds to the next iteration if the search was cut off at som
 ```
 
 There is one final complication.
-When we increase the depth of search, we may find some new proof s, but we will also find all the old proof s that were found on the previous iteration.
+When we increase the depth of search, we may find some new proofs, but we will also find all the old proofs that were found on the previous iteration.
 We can modify `show-prolog-vars` to only print proofs that are found with a depth less than the increment-that is, those that were not found on the previous iteration.
 
 ```lisp
@@ -1024,7 +1024,8 @@ We also introduce a way to attach functions to predicates to do forward-chaining
 
 ### Higher-Order Predications
 
-First we will tackle the problem of answering questions like "What kinds of animais are there?" Paradoxically, the key to allowing more expressiveness in this case is to invent a new, more limited language and insist that all assertions and queries are made in that language.
+First we will tackle the problem of answering questions like "What kinds of animals are there?"
+Paradoxically, the key to allowing more expressiveness in this case is to invent a new, more limited language and insist that all assertions and queries are made in that language.
 That way, queries that would have been higher-order in the original language become first-order in the restricted language.
 
 The language admits three types of objects: *categories, relations*, and *individuals.* A category corresponds to a one-place predicate, a relation to a two-place predicate, and an individual to constant, or zero-place predicate.
@@ -1063,15 +1064,15 @@ The form (rel *R A B*) means that every *R* holds between an individual of *A* a
 | `(and` *P Q...*) | *P ^ Q...*                                                                                                         |
 
 Queries in the language, not surprisingly, have the same form as assertions, except that they may contain variables as well as constants.
-Thus, to find out what kinds of animais there are, use the query `(sub ?kind animal)`.
-To find out what individual animais there are, use the query `(ind ?x animal)`.
-To find out what individual animais of what kinds there are, use:
+Thus, to find out what kinds of animals there are, use the query `(sub ?kind animal)`.
+To find out what individual animals there are, use the query `(ind ?x animal)`.
+To find out what individual animals of what kinds there are, use:
 
 ```lisp
 (and (sub ?kind animal) (ind ?x ?kind))
 ```
 
-The implemention of this new language can be based directly on the previous implementation of dtrees.
+The implementation of this new language can be based directly on the previous implementation of dtrees.
 Each assertion is stored as a fact in a dtree, except that the components of an and assertion are stored separately.
 The function `add-fact` does this:
 
@@ -1098,14 +1099,14 @@ Conceptually, the function to do this, `retrieve-fact`, should be as simple as t
 Unfortunately, there are some complications.
 Think about what must be done in `retrieve-conjunction`.
 It is passed a list of conjuncts and must return a list of binding lists, where each binding list satisfies the query.
-For example, to find out what people were born on July Ist, we could use the query:
+For example, to find out what people were born on July 1st, we could use the query:
 
 ```lisp
 (and (val birthday ?p july-1) (ind ?p person))
 ```
 
 `retrieve-conjunction` could solve this problem by first calling `retrieve-fact` on `(val birthday ?p july-1)`.
-Once that is done, there is only one conjunct remaining, but in general there could be several, so we need to call `retrieve-conjunction` recursively with two arguments: the remainingconjuncts, and the resultthat `retrieve-fact` gave for the first solution.
+Once that is done, there is only one conjunct remaining, but in general there could be several, so we need to call `retrieve-conjunction` recursively with two arguments: the remaining conjuncts, and the result that `retrieve-fact` gave for the first solution.
 Since `retrieve-fact` returns a list of binding lists, it will be easiest if `retrieve-conjunction` accepts such a list as its second argument.
 Furthermore, when it comes time to call `retrieve-fact` on the second conjunct, we will want to respect the bindings set up by the first conjunct.
 So `retrieve-fact` must accept a binding list as its second argument.
@@ -1168,7 +1169,7 @@ Here is a short example where `add-fact` is used to add facts about bears and do
 > (add-fact '(val latin-name dog canis-familiaris)) => T
 ```
 
-Now `retrieve-fact` is used to answer three questions: What kinds of animais are there?
+Now `retrieve-fact` is used to answer three questions: What kinds of animals are there?
 What are the Latin names of each kind of animal?
 and What are the colors of each individual bear?
 
@@ -1427,7 +1428,7 @@ To support the frame notation, we define the macros `a` and `each` to make asser
  '(add-fact ',(translate-exp (cons 'a args))))
 (defmacro each (&rest args)
  "Define a new category and assert facts about it in the data base."
- '(add-fact ',(transiate-exp (cons 'each args))))
+ '(add-fact ',(translate-exp (cons 'each args))))
 (defmacro ?? (&rest queries)
  "Return a list of answers satisfying the query or queries."
  '(retrieve-setof
@@ -1437,10 +1438,10 @@ To support the frame notation, we define the macros `a` and `each` to make asser
 
 All three of these macros call on `translate-exp` to translate from the frame syntax to the primitive syntax.
 Note that an `a` or `each` expression is computing a conjunction of primitive relations, but it is also computing a *term* when it is used as the nested value of a slot.
-It would be possible to do this by returning multiple values, but it is easier to build `transiate-exp` as a set of local functions that construct facts and push them on the local variable `conjuncts`.
+It would be possible to do this by returning multiple values, but it is easier to build `translate-exp` as a set of local functions that construct facts and push them on the local variable `conjuncts`.
 At the end, the list of `conjuncts` is returned as the value of the translation.
-The local functions `transiate-a` and `transiate-each` return the atom that represents the term they are translating.
-The local function `translate` translates any kind of expression, `transiate-siot` handles a slot, and `collect-fact` is responsible for pushing a fact onto the list of conjuncts.
+The local functions `translate-a` and `translate-each` return the atom that represents the term they are translating.
+The local function `translate` translates any kind of expression, `translate-slot` handles a slot, and `collect-fact` is responsible for pushing a fact onto the list of conjuncts.
 The optional argument `query-mode-p` tells what to do if the individual is not provided in an `a` expression.
 If `query-mode-p` is true, the individual will be represented by a variable; otherwise it will be a Skolem constant.
 
@@ -1542,13 +1543,13 @@ First, we could add multiple truth values beyond the simple "true" and "false." 
 Second, we could introduce the idea of *possible worlds.*
 That is, the truth of a proposition could be unknown in the current world, but true if we assume *p*, and false if we assume *q.*
 In the possible world approach, this is handled by calling the current world *W*, and then creating a new world *W*<sub>1</sub>, which is just like *W* except that *p* is true, and *W*<sub>2</sub>, which is just like *W* except that *q* is true.
-By doing reasoning in different worlds we can make predictions about the future, resolve ambiguitites about the current state, and do reasoning by cases.
+By doing reasoning in different worlds we can make predictions about the future, resolve ambiguities about the current state, and do reasoning by cases.
 
 For example, possible worlds allow us to solve Moore's communism/democracy problem ([page 466](#p466)).
 We create two new possible worlds, one where *E* is a democracy and one where it is communist.
 In each world it is easy to derive that there is a democracy next to a communist country.
 The trick is to realize then that the two worlds form a partition, and that therefore the assertion holds in the original "real" world as well.
-This requires an interaction between the Prolog-based tactical reasoning going on within a world and the planning-based strategie reasoning that decides which worlds to consider.
+This requires an interaction between the Prolog-based tactical reasoning going on within a world and the planning-based strategic reasoning that decides which worlds to consider.
 
 We could also add a *truth maintenance system* (or TMS) to keep track of the assumptions or justifications that lead to each fact being considered true.
 A truth maintenance system can lessen the need to backtrack in a search for a global solution.
@@ -1574,7 +1575,7 @@ The following is an `nalist` showing six facts indexed under three different wor
 
 The fetching routine will remain unchanged, but the postfetch processing will have to sort through the nalists to find only the facts in the current world.
 It would also be possible for `fetch` to do this work, but the reasoning is that most facts will be indexed under the "real world," and only a few facts will exist in alternative, hypothetical worlds.
-Therefore, we should delay the effort of sorting through the answers to elimina te those answers in the wrong world-it may be that the first answer fetched will suffice, and then it would have been a waste to go through and eliminate other answers.
+Therefore, we should delay the effort of sorting through the answers to eliminate those answers in the wrong world-it may be that the first answer fetched will suffice, and then it would have been a waste to go through and eliminate other answers.
 The following changes to `index` and `dtree-index` add support for worlds:
 
 ```lisp
@@ -1664,7 +1665,7 @@ We also include a definition of the default initial world.
 The function `use-world` is used to switch to a new world.
 It first makes the current world and all its parents no longer current, and then makes the new chosen world and all its parents current.
 The function `use-new-world` is more efficient in the common case where you want to create a new world that inherits from the current world.
-It doesn't have to turn any worlds off; it j ust crea tes the new world and makes it current.
+It doesn't have to turn any worlds off; it just creates the new world and makes it current.
 
 ```lisp
 (defun use-world (world)
@@ -1840,7 +1841,7 @@ This approach was pioneered by [Doyle (1979)](B9780080571157500285.xhtml#bb0340)
 Doyle tried to change the name to "reason maintenance,' in (1983), but it was too late.
 The version in widest used today is the assumption-based truth maintenance system, or ATMS, developed by de Kleer (1986a,b,c).
 [Charniak et al.
-(1987)](B9780080571157500285.xhtml#bb0180) present a complete Common Lisp implementation of a McAllester-styleTMS.
+(1987)](B9780080571157500285.xhtml#bb0180) present a complete Common Lisp implementation of a McAllester-style TMS.
 
 There is little communication between the logic programming and knowledge representation communities, even though they cover overlapping territory.
 [Colmerauer (1990)](B9780080571157500285.xhtml#bb0250) and [Cohen (1990)](B9780080571157500285.xhtml#bb0230) describe Logic Programming languages that address some of the issues covered in this chapter.
@@ -1878,8 +1879,8 @@ This support has already been provided for dtrees, but you will have to provide 
 
 **Exercise  14.9 [h]** Integrate the language described in [section 14.10](#s0055) and the frame syntax from [section 14.10](#s0055) with the extended Prolog compiler from the previous exercise.
 
-**Exercise  14.10 [d]** Build a strategie reasoner that decides when to create a possible world and does reasoning by cases over these worlds.
-Use it to solve Moore 's problem ([page 466](#p466)).
+**Exercise  14.10 [d]** Build a strategic reasoner that decides when to create a possible world and does reasoning by cases over these worlds.
+Use it to solve Moore's problem ([page 466](#p466)).
 
 ## 14.13 Answers
 

--- a/docs/chapter15.md
+++ b/docs/chapter15.md
@@ -753,7 +753,7 @@ Polynomials are not closed under division, so `poly/poly` will return a rational
 
 Now that we can divide polynomials, the final step is to reinstate the logarithmic, exponential, and trigonometric functions.
 The problem is that if we allow all these functions, we get into problems with canonical form again.
-For example, the following three expressions are all equivalent  :
+For example, the following three expressions are all equivalent:
 
 <img src="images/chapter15/si7_e.svg"
 onerror="this.src='images/chapter15/si7_e.png'; this.onerror=null;"

--- a/docs/chapter15.md
+++ b/docs/chapter15.md
@@ -317,7 +317,7 @@ A doubly nested loop multiplies each coefficient of `p` and `q` and adds the `re
 
 Both `poly+poly` and `poly*poly` make use of the function `normalize-poly` to "normalize" the `result`.
 The idea is that `(- (^ 5) (^ x 5))` should return 0, not `#(x 0 0 0 0 0 0)`.
-Note that `normal` ize`-poly` is a destructive operation: it calls `delete,` which can actually alter its argument.
+Note that `normalize-poly` is a destructive operation: it calls `delete,` which can actually alter its argument.
 Normally this is a dangerous thing, but since `normalize-poly` is replacing something with its conceptual equal, no harm is done.
 
 ```lisp
@@ -396,7 +396,7 @@ Write a function to integrate polynomials and install it in `prefix->canon`.
 onerror="this.src='images/chapter15/si3_e.png'; this.onerror=null;"
 alt="\int_{a}^{b} y\, dx">.
 You will need to make up a suitable notation and properly install it in both `infix->prefix` and `prefix->canon`.
-A full implementation of this feature would have to consider infinity as a bound, as well as the problem of integrating over singularises.
+A full implementation of this feature would have to consider infinity as a bound, as well as the problem of integrating over singularities.
 You need not address these problems.
 
 ## 15.3 Converting between Infix and Prefix
@@ -538,8 +538,8 @@ How much faster is the polynomial-based code than the rule-based version?
 Unfortunately, we can't answer that question directly.
 We can time `(simp ' ( (1 + x + y + z) ^ 15)))`.
 This takes only a tenth of a second, but that is because it is doing no work at all-the answer is the same as the input!
-Alternately, we can take the expression computed by `(poly^n r 15)`, convert it to prefix, and pass that `to simplify.
-simplify` takes 27.8 seconds on this, so the rule-based version is much slower.
+Alternately, we can take the expression computed by `(poly^n r 15)`, convert it to prefix, and pass that to `simplify`.
+`simplify` takes 27.8 seconds on this, so the rule-based version is much slower.
 [Section 9.6](B9780080571157500091.xhtml#s0035) describes ways to speed up the rule-based program, and a comparison of timing data appears on [page 525](#p525).
 
 There are always surprises when it comes down to measuring timing data.
@@ -567,7 +567,7 @@ We took an existing function, poly^n, added a single cond clause, and changed it
 (This turned out to be a bad idea, but that's beside the point.
 It would be a good idea for raising integers to powers.)
 The reasoning that allows the change is simple: First, *p<sup>n</sup>* is certainly equal to (*p*<sup>*n*/2</sup>)<sup>2</sup> when *n* is even, so the change can't introduce any wrong answers.
-Second, the change continues the policy of decrementing *n* on every recursive call, so the function must eventually termina te (when *n =* 0).
+Second, the change continues the policy of decrementing *n* on every recursive call, so the function must eventually terminate (when *n* = 0).
 If it gives no wrong answers, and it terminates, then it must give the right answer.
 
 In contrast, making the change for an iterative algorithm is more complex.
@@ -751,7 +751,7 @@ Polynomials are not closed under division, so `poly/poly` will return a rational
 
 ## 15.6 Extending Rational Expressions
 
-Now that we can divide polynomials, the final step is to reinstate the logarithmic, exponential, and trigonometrie functions.
+Now that we can divide polynomials, the final step is to reinstate the logarithmic, exponential, and trigonometric functions.
 The problem is that if we allow all these functions, we get into problems with canonical form again.
 For example, the following three expressions are all equivalent  :
 
@@ -782,7 +782,7 @@ A brief history of symbolic algebra systems is given in [chapter 8](B97800805711
 
 ## 15.8 Exercises
 
-**Exercise 15.7 [h]** Implement an extension of the rationals to include logarithmic, exponential, and trigonometrie functions.
+**Exercise 15.7 [h]** Implement an extension of the rationals to include logarithmic, exponential, and trigonometric functions.
 
 **Exercise 15.8 [m]** Modify `deriv` to handle the extended rational expressions.
 

--- a/docs/chapter16.md
+++ b/docs/chapter16.md
@@ -5,7 +5,7 @@
 
 > -Nicholas Murray Butler (1862-1947)
 
-In the 1970s there was terrifie interest in the area of *knowledge-based expert systems*.
+In the 1970s there was terrific interest in the area of *knowledge-based expert systems*.
 An expert system or knowledge-based system is one that solves problems by applying knowledge that has been garnered from one or more experts in a field.
 Since these experts will not in general be programmers, they will very probably express their expertise in terms that cannot immediately be translated into a program.
 It is the goal of expert-system research to come up with a representation that is flexible enough to handle expert knowledge, but still capable of being manipulated by a computer program to come up with solutions.
@@ -1317,5 +1317,4 @@ This suggests that the system should have some way of dealing with mutually excl
 One way would be to accept only yes responses for Boolean parameters, but have the input routine translate no to `(yes -1)` and `(no *cf*)` to `(yes 1-*cf*)`.
 Another possibility would be to have `update-cf check` to see if any certainty factor on a mutually exclusive value is 1, and if so, change the other values to -1.
 
-**Answer 16.18** Add the clause `(stop (throw 'stop nil))` to the case statement inask-valsandwrapa `(catch 'stop ...)` around the code in `emycin`.
-
+**Answer 16.18** Add the clause `(stop (throw 'stop nil))` to the `case` statement in `ask-vals` and wrap a `(catch 'stop ...)` around the code in `emycin`.

--- a/docs/chapter16.md
+++ b/docs/chapter16.md
@@ -166,7 +166,7 @@ A and B => .9C
 to say that A and B imply C with .9 certainty.
 EMYCIN simply multiplies the rule's cf by the combined cf of the premise.
 So if A has cf .6 and B has cf .4, then the premise as a whole has cf .4 (the minimum of A and B), which is multiplied by .9 to get .36.
-The .36 is then combined with any exisiting cf for C.
+The .36 is then combined with any existing cf for C.
 If C is previously unknown, then combining .36 with 0 will give .36.
 If C had a prior cf of .76, then the new cf would be .36 + .76 - (.36 x .76) = .8464.
 
@@ -1259,7 +1259,7 @@ Eventually, the need arose for a rule that said, "If any of the organisms in a c
 Implement a mechanism that keeps track of the author and date of creation of each rule, and allows the author to add documentation explaining the rationale for the rule.
 
 **Exercise  16.16 [m]** It is difficult to come up with the perfect prompt for each parameter.
-One solution is not to insist that one promptfits all users, but rather to allow the expert to supply three different prompts: a normal prompt, a verbose prompt (or reprompt) for when the user replies with a ?, and a terse prompt for the experienced user.
+One solution is not to insist that one prompt fits all users, but rather to allow the expert to supply three different prompts: a normal prompt, a verbose prompt (or reprompt) for when the user replies with a ?, and a terse prompt for the experienced user.
 Modify `defparm` to accommodate this concept, add a command for the user to ask for the terse prompts, and change `ask-vals` to use the proper prompt.
 
 The remaining exercises cover three additional replies the user can make: `how`, `stop`, and `change`.

--- a/docs/chapter17.md
+++ b/docs/chapter17.md
@@ -232,7 +232,7 @@ But since there are a finite number of labelings initially (no more than six per
 The function `consistent-labelings` is passed a vertex.
 It gets all the labels for this vertex from the neighboring vertexes, collecting them in `neighbor-labels`.
 It then checks all the labels on the current vertex, keeping only the ones that are consistent with all the neighbors' constraints.
-The auxiliary function `labels-for` finds the labels for a particular neighbor at a vertex, and reverse-1 abel accounts for the fact that L and R labels are interpreted with respect to the vertex they point at.
+The auxiliary function `labels-for` finds the labels for a particular neighbor at a vertex, and `reverse-label` accounts for the fact that L and R labels are interpreted with respect to the vertex they point at.
 
 ```lisp
 (defun consistent-labelings (vertex)
@@ -389,7 +389,7 @@ Here again is the `defdiagram` description for the cube shown in [figure 17.6](#
 
 The macro `defdiagram` calls `construct-diagram` to do the real work.
 It would be feasible to have `defdiagram` expand into a `defvar,` making the names be special variables.
-But then it would be the user`'s` responsibility to make copies of such a variable before passing it to a destructive function.
+But then it would be the user's responsibility to make copies of such a variable before passing it to a destructive function.
 Instead, I use `put-diagram` and `diagram` to put and get diagrams in a table, `diagram` retrieves the named diagram and makes a copy of it.
 Thus, the user cannot corrupt the original diagrams stored in the table.
 Another possibility would be to have `defdiagram` expand into a function definition for `name` that returns a copy of the diagram.

--- a/docs/chapter17.md
+++ b/docs/chapter17.md
@@ -10,7 +10,7 @@ Instead I think it is an elegant case study of a paradigm we can expect to see a
 
 This book touches only the areas of AI that deal with abstract reasoning.
 There is another side of AI, the field of *robotics,* that deals with interfacing abstract reasoning with the real world through sensors and motors.
-A robot receives input from cameras, microphones, sonar, and touch-sensitive devices, and produces "ouput" by moving its appendages or generating sounds.
+A robot receives input from cameras, microphones, sonar, and touch-sensitive devices, and produces "output" by moving its appendages or generating sounds.
 The real world is a messier place than the abstract worlds we have been covering.
 A robot must deal with noisy data, faulty components, and other agents and events in the world that can affect changes in the environment.
 
@@ -42,10 +42,10 @@ We will assume that this is not the case.
 Given a diagram that fits these three restrictions, our goal is to identify each line, placing it in one of three classes:
 
 1.  A convex line separates two visible faces of a polyhedron such that a line from one face to the other would lie inside the polyhedron.
-It will be marked with a plus sign:+.
+It will be marked with a plus sign: `+`.
 
 2.  A concave line separates two faces of two polyhedra such that a line between the two spaces would pass through empty space.
-It will be marked with a minus sign:-.
+It will be marked with a minus sign: `-`.
 
 3.  A boundary line denotes the same physical situation as a convex line, but the diagram is oriented in such a way that only one of the two faces of the polyhedron is visible.
 Thus, the line marks the boundary between the polyhedron and the background.
@@ -109,7 +109,7 @@ Keep going until the diagram is either unambiguous or inconsistent.
 
 That completes the sketch of the line-labeling algorithm.
 We are now ready to implement a labeling program.
-It's glossary is in [figure 17.5](#f0030).
+Its glossary is in [figure 17.5](#f0030).
 
 | []()                                                |
 |-----------------------------------------------------|

--- a/docs/chapter18.md
+++ b/docs/chapter18.md
@@ -773,7 +773,7 @@ Black is able to increase the piece difference dramatically as the game progress
 After 17 moves, white is down to only one piece:
 
 ```lisp
-     1 2 3 4 5 6 7 8    [@=20 0=1 (+19)]
+     1 2 3 4 5 6 7 8  [@=20 0=1 (+19)]
   10 0 @ . . . . . .
   20 . @ . . . @ @ .
   30 @ @ @ @ @ @ . .
@@ -788,7 +788,7 @@ Although behind by 19 points, white is actually in a good position, because the 
 White is able to maintain good position while being numerically far behind black, as shown in these positions later in the game:
 
 ```lisp
-     1 2 3 4 5 6 7 8    [@=32 0=15 (+17)]
+     1 2 3 4 5 6 7 8  [@=32 0=15 (+17)]
   10 0 0 0 0 @ @ 0 0
   20 @ @ 0 @ @ @ @ @
   30 @ @ 0 0 @ 0 @ @
@@ -800,7 +800,7 @@ White is able to maintain good position while being numerically far behind black
 ```
 
 ```
-     1 2 3 4 5 6 7 8    [@=34 0=19 (+15)]
+     1 2 3 4 5 6 7 8  [@=34 0=19 (+15)]
   10 0 0 0 0 @ @ 0 0
   20 @ @ 0 @ @ @ @ @
   30 @ @ 0 0 @ 0 @ @
@@ -814,7 +814,7 @@ White is able to maintain good position while being numerically far behind black
 After some give-and-take, white gains the advantage for good by capturing eight pieces on a move to square 85 on the third-to-last move of the game:
 
 ```lisp
-     1 2 3 4 5 6 7 8    [@=31 0=30 (+1)]
+     1 2 3 4 5 6 7 8  [@=31 0=30 (+1)]
   10 0 0 0 0 @ @ 0 0
   20 @ @ 0 0 @ @ @ 0
   30 @ @ 0 0 0 @ @ 0
@@ -822,13 +822,13 @@ After some give-and-take, white gains the advantage for good by capturing eight 
   50 0 @ 0 @ 0 @ @ 0
   60 0 @ 0 @ @ @ @ 0
   70 0 @ @ @ @ @ 0 0
-  80 0 @ @ @ . . .0
+  80 0 @ @ @ . . . 0
 
 0 moves to 85.
 ```
 
 ```
-     1 2 3 4 5 6 7 8    [@=23 0=39 (-16)]
+     1 2 3 4 5 6 7 8  [@=23 0=39 (-16)]
   10 0 0 0 0 @ @ 0 0
   20 @ @ 0 0 @ @ @ 0
   30 @ @ 0 0 0 @ @ 0
@@ -842,7 +842,7 @@ After some give-and-take, white gains the advantage for good by capturing eight 
 ```
 
 ```
-     1 2 3 4 5 6 7 8    [@=26 0=37 (-11)]
+     1 2 3 4 5 6 7 8  [@=26 0=37 (-11)]
   10 0 0 0 0 @ @ 0 0
   20 @ @ 0 0 @ @ @ 0
   30 @ @ 0 0 0 @ @ 0
@@ -885,7 +885,7 @@ The same things happen, although black's doom takes a bit longer to unfold.
 Black slowly builds up an advantage:
 
 ```lisp
-     1 2 3 4 5 6 7 8    [@=21 0=8 (+13)]
+     1 2 3 4 5 6 7 8  [@=21 0=8 (+13)]
   10 . . @ @ @ @ @ .
   20 . @ . @ 0 @ . .
   30 0 @ @ 0 @ 0 0 .
@@ -900,7 +900,7 @@ But at this point white has clear access to the upper left corner, and through t
 Still, black maintains a material edge as the game goes on:
 
 ```lisp
-     1 2 3 4 5 6 7 8    [@=34 0=11 (+23)]
+     1 2 3 4 5 6 7 8  [@=34 0=11 (+23)]
   10 0 . @ @ @ @ @ .
   20 . 0 0 @ @ @ . .
   30 0 @ 0 0 @ @ @ @
@@ -914,7 +914,7 @@ Still, black maintains a material edge as the game goes on:
 But eventually white's weighted-squares strategy takes the lead:
 
 ```lisp
-     1 2 3 4 5 6 7 8    [@=23 0=27 (-4)]
+     1 2 3 4 5 6 7 8  [@=23 0=27 (-4)]
   10 0 0 0 0 0 0 0 0
   20 @ @ 0 @ @ @ . .
   30 0 @ 0 0 @ @ @ @
@@ -928,7 +928,7 @@ But eventually white's weighted-squares strategy takes the lead:
 and is able to hold on to win:
 
 ```lisp
-     1 2 3 4 5 6 7 8    [@=24 0=40 (-16)]
+     1 2 3 4 5 6 7 8  [@=24 0=40 (-16)]
   10 0 0 0 0 0 0 0 0
   20 @ @ 0 @ 0 0 @ @
   30 0 @ 0 0 @ @ @ @
@@ -946,7 +946,7 @@ There are many problems with the weighted-squares evaluation function.
 Consider again this position from the first game above:
 
 ```lisp
-     1 2 3 4 5 6 7 8    [@=20 0=1 (+19)]
+     1 2 3 4 5 6 7 8  [@=20 0=1 (+19)]
   10 0 @ . . . . . .
   20 . @ . . . @ @ .
   30 @ @ @ @ @ @ . .
@@ -1310,11 +1310,11 @@ Here is a comparison of five strategies that search only 1 ply:
                 #'random-strategy)
     5 10
     '(count-difference mobility weighted modified-weighted random))
-COUNT-DIFFERENCE      12.5:   --- 3.0 2.5 0.0 7.0
-MOBILITY                      20.5:   7.0 --- 1.5 5.0 7.0
-WEIGHTED                      28.0:   7.5 8.5 --- 3.0 9.0
-MODIFIED-WEIGHTED    31.5: 10.0 5.0 7.0 --- 9.5
-RANDOM                            7.5:   3.0 3.0 1.0 0.5 ---
+COUNT-DIFFERENCE   12.5:  --- 3.0 2.5 0.0 7.0
+MOBILITY           20.5:  7.0 --- 1.5 5.0 7.0
+WEIGHTED           28.0:  7.5 8.5 --- 3.0 9.0
+MODIFIED-WEIGHTED  31.5: 10.0 5.0 7.0 --- 9.5
+RANDOM              7.5:  3.0 3.0 1.0 0.5 ---
 ```
 
 The parameter `n-pairs` is 5, meaning that each strategy plays five games as black and five as white against each of the other four strategies, for a total of 40 games for each strategy and 100 games overall.
@@ -1324,16 +1324,16 @@ Now we see what happens when the search depth is increased to 4 ply (this will t
 
 ```lisp
 > (round-robin
-    (list (alpha-beta-searcher 4 #'count-difference)
-                (alpha-beta-searcher 4 #'weighted-squares)
-                (alpha-beta-searcher 4 #'modified-weighted-squares)
-                #'random-strategy)
-    5 10
-    '(count-difference weighted modified-weighted random))
-COUNT-DIFFERENCE      12.0:   --- 2.0 0.0 10.0
-WEIGHTED                      23.5:   8.0 --- 5.5 10.0
-MODIFIED-WEIGHTED    24.5: 10.0 4.5 --- 10.0
-RANDOM                            0.0:   0.0 0.0 0.0   ---
+  (list (alpha-beta-searcher 4 #'count-difference)
+        (alpha-beta-searcher 4 #'weighted-squares)
+        (alpha-beta-searcher 4 #'modified-weighted-squares)
+        #'random-strategy)
+  5 10
+  '(count-difference weighted modified-weighted random))
+COUNT-DIFFERENCE   12.0:  --- 2.0 0.0 10.0
+WEIGHTED           23.5:  8.0 --- 5.5 10.0
+MODIFIED-WEIGHTED  24.5: 10.0 4.5 --- 10.0
+RANDOM              0.0:  0.0 0.0 0.0  ---
 ```
 
 Here the random strategy does not win any games-an indication that the other strategies are doing something right.

--- a/docs/chapter18.md
+++ b/docs/chapter18.md
@@ -2258,7 +2258,7 @@ Here's how the macro would be used to define the piece data type, and the code p
 ```
 
 A more general facility would, like `defstruct`, provide for several options.
-For example, it might allow for a documentation string for the type and each constant, and for a : `conc-name`, so the constants could have names like `piece-empty` instead of `empty`.
+For example, it might allow for a documentation string for the type and each constant, and for a `:conc-name`, so the constants could have names like `piece-empty` instead of `empty`.
 This would avoid conflicts with other types that wanted to use the same names.
 The user might also want the ability to start the values at some number other than zero, or to assign specific values to some of the symbols.
 

--- a/docs/chapter18.md
+++ b/docs/chapter18.md
@@ -5,7 +5,7 @@
 
 > -Suzuki Roshi, Zen Master
 
-**G**ame playing has been the target of much early work in AI for three reasons.
+Game playing has been the target of much early work in AI for three reasons.
 First, the rules of most games are formalized, and they can be implemented in a computer program rather easily.
 Second, in many games the interface requirements are trivial.
 The computer need only print out its moves and read in the opponent's moves.
@@ -1608,7 +1608,7 @@ Bill's evaluation function is fast enough to search 6-8 ply under tournament con
 (However, Lee is only a novice Othello player; his real interest is in speech recognition; see [Waibel and Lee 1991](B9780080571157500285.xhtml#bb1285).) There are other programs that also play at a high level, but they have not been written up in the AI literature as Iago and Bill have.
 
 In this section we present an evaluation function based on Iago's, although it also contains elements of Bill, and of an evaluation function written by Eric Wefald in 1989.
-The evaluation function makes use of two main features: *mobilityand edge stability*.
+The evaluation function makes use of two main features: *mobility and edge stability*.
 
 ### Mobility
 
@@ -1957,7 +1957,7 @@ Now we have a measure of the three factors: current mobility, potential mobility
 All that remains is to find a good way to combine them into a single evaluation metric.
 The combination function used by [Rosenbloom (1982)](B9780080571157500285.xhtml#bb1000) is a linear combination of the three factors, but each factor's coefficient is dependent on the move number.
 Rosenbloom's features are normalized to the range [-1000, 1000]; we normalize to the range [-1, 1] by doing a division after multiplying by the coefficient.
-That allows us to use fixnuums for the coefficients.
+That allows us to use fixnums for the coefficients.
 Since our three factors are not calculated in quite the same way as Rosenbloom's, it is not surprising that his coefficients are not the best for our program.
 The edge coefficient was doubled and the potential coefficient cut by a factor of five.
 

--- a/docs/chapter19.md
+++ b/docs/chapter19.md
@@ -1009,10 +1009,10 @@ It's up to you to design the grammar, but you should allow input something like 
 
 ```lisp
 > (meaning '(play 1 to 5 from CD shuffled and
-                          record 1 to 5 from CD and 1 and 3 and 7 from 1))
+             record 1 to 5 from CD and 1 and 3 and 7 from 1))
 (PROGN (PLAY '(15 2 3 4) :FROM 'CD)
-              (RECORD '(12345) :FROM 'CD)
-              (RECORD '(1 3 7) :FROM '1))
+       (RECORD '(12345) :FROM 'CD)
+       (RECORD '(1 3 7) :FROM '1))
 ```
 
 This assumes that the functions play and record take keyword arguments (with defaults) for : `from` and : `to`.

--- a/docs/chapter19.md
+++ b/docs/chapter19.md
@@ -2,7 +2,7 @@
 ## Introduction to Natural Language
 
 > Language is everywhere.
-It permeates our thoughts mediates our relations with others, and even creeps into our dreams.
+It permeates our thoughts, mediates our relations with others, and even creeps into our dreams.
 The overwhelming bulk of human knowledge is stored and transmitted in language.
 Language is so ubiquitous that we take it for granted but without it, society as we know it would be impossible.
 >
@@ -10,7 +10,7 @@ Language is so ubiquitous that we take it for granted but without it, society as
 >
 > Language and its Structure (1967)
 
-Anatural language is a language spoken by people, such as English, German, or Tagalog.
+A natural language is a language spoken by people, such as English, German, or Tagalog.
 This is in opposition to artificial languages like Lisp, FORTRAN, or Morse code.
 Natural language processing is an important part of AI because language is intimately connected to thought.
 One measure of this is the number of important books that mention language and thought in the title: in AI, Schank and Colby's *Computer Models of Thought and Language;* in linguistics, Whorf's *Language, Thought, and Reality* (and Chomsky's *Language and Mind;)* in philosophy, Fodor's *The Language of Thought;* and in psychology, Vygotsky's *Thought and Language* and John Anderson's *Language, Memory, and Thought.* Indeed, language is the trait many think of as being the most characteristic of humans.
@@ -304,7 +304,7 @@ Besides memoizing, the only change is to clear the memoization table within pars
 ```
 
 In normal human language use, memoization would not work very well, since the interpretation of a phrase depends on the context in which the phrase was uttered.
-But with context-f ree grammars we have a guarantee that the context cannot af f ect the interpretation.
+But with context-free grammars we have a guarantee that the context cannot affect the interpretation.
 The call `(parse words)` must return all possible parses for the words.
 We are free to choose between the possibilities based on contextual information, but context can never supply a new interpretation that is not in the context-free list of parses.
 
@@ -1095,12 +1095,11 @@ An infinite structure of NPs is explored before even the first word is considere
 
 Bottom-up parsers are stymied by rules with null right-hand sides: `(X -> O)`.
 Note that I was careful to exclude such rules in my grammars earlier.
-<!--- indent below -->
 
 ```lisp
 (defun parser (words &optional (cat 's))
   "Parse a list of words; return only parses with no remainder."
-  (mapcar #'parse-tree (compiete-parses (parse words cat))))
+  (mapcar #'parse-tree (complete-parses (parse words cat))))
 
 (defun parse (tokens start-symbol)
   "Parse a list of tokens, return parse trees and remainders."
@@ -1182,7 +1181,8 @@ Rarely, `rotatef` is used with more than two arguments, `(rotatef a b c)` is lik
 Some erroneous expressions are underspecified and may return different results in different implementations, but we will ignore that problem.
 
 <a id="fn19-2"></a><sup>[2](#tfn19-2)</sup>
-The number of parses of sentences of this kind is the same as the number of bracketings of a arithmetic expression, or the number of binary trees with a given number of leaves.
-The resulting sequence (1,2,5,14,42,...) is known as the Catalan Numbers.
+The number of parses of sentences of this kind is the same as the number of bracketings of an arithmetic expression, or the number of binary trees with a given number of leaves.
+The resulting sequence (1, 2, 5, 14, 42, ...) is known as the Catalan Numbers.
+
 This kind of ambiguity is discussed by [Church and Patil (1982)](B9780080571157500285.xhtml#bb0200) in their article *Coping with Syntactic Ambiguity, or How to Put the Block in the Box on the Table.*
 

--- a/docs/chapter19.md
+++ b/docs/chapter19.md
@@ -115,7 +115,7 @@ Compare this to the treatment on [page 40](B9780080571157500029.xhtml#p40).
 
 Now we're ready to define the parser.
 The main function parser takes a list of words to parse.
-It calls parse, which returns a list of all parses that parse some subsequence of the words, starting at the beginning.
+It calls `parse`, which returns a list of all parses that parse some subsequence of the words, starting at the beginning.
 parser keeps only the parses with no remainder-that is, the parses that span all the words.
 
 ```lisp
@@ -131,7 +131,8 @@ parser keeps only the parses with no remainder-that is, the parses that span all
 The function parse looks at the first word and considers each category it could be.
 It makes a parse of the first word under each category, and calls extend - parse to try to continue to a complete parse.
 parse uses mapcan to append together all the resulting parses.
-As an example, suppose we are trying to parse "the man took the ball." pa rse would find the single lexical rule for "the" and call extend-parse with a parse with tree (Art the) and remainder "man took the ball," with no more categories needed.
+As an example, suppose we are trying to parse "the man took the ball."
+`parse` would find the single lexical rule for "the" and call extend-parse with a parse with tree (Art the) and remainder "man took the ball," with no more categories needed.
 
 `extend-parse` has two cases.
 If the partial parse needs no more categories to be complete, then it returns the parse itself, along with any parses that can be formed by extending parses starting with the partial parse.
@@ -288,7 +289,7 @@ Evaluation of (LENGTH (PARSER S)) took 33.11 Seconds of elapsed time.
 The sentence S has 10 parses, since there are two ways to parse the subject NP and five ways to parse the VP.
 It took 33 seconds to discover these 10 parses with the parse function as it was written.
 
-We can improve this dramatically by memoizing parse (along with the table- lookup functions).
+We can improve this dramatically by memoizing `parse` (along with the table-lookup functions).
 Besides memoizing, the only change is to clear the memoization table within parser.
 
 ```lisp
@@ -317,7 +318,7 @@ The function use is introduced to tell the table-lookup functions that they are 
   (length (setf *grammar* grammar)))
 ```
 
-Now we run the benchmark again with the memoized version of pa rse:
+Now we run the benchmark again with the memoized version of `parse`:
 
 ```lisp
 > (time (length (parser s)))
@@ -365,7 +366,7 @@ This can be programmed very simply by having `lexical-rules` return a list of th
       (mapcar #'(lambda (cat) `(,cat -> ,word)) *open-categories*)))
 ```
 
-With memoization of lexical - rules, this means that the lexicon is expanded every time an unknown word is encountered.
+With memoization of `lexical-rules`, this means that the lexicon is expanded every time an unknown word is encountered.
 Let's try this out:
 
 ```lisp
@@ -419,7 +420,7 @@ Now let's stretch the imagination one more time by assuming that this CD player 
 Let's first consider the relevant data structures.
 We need to add a component for the semantics to both the rule and tree structures.
 Once we've done that, it is clear that trees are nothing more than instances of rules, so their definitions should reflect that.
-Thus, I use an : incl ude defstruct to define trees, and I specify no copier function, because copy-tree is already a Common Lisp function, and I don't want to redefine it.
+Thus, I use an `:include` defstruct to define trees, and I specify no copier function, because copy-tree is already a Common Lisp function, and I don't want to redefine it.
 To maintain consistency with the old new-tree function (and to avoid having to put in all those keywords) I define the constructor new-tree.
 This option to `defstruct makes (new-tree a b c)` equivalent to `(make-tree :lhs a :sem b :rhs c)`.
 
@@ -431,7 +432,7 @@ This option to `defstruct makes (new-tree a b c)` equivalent to `(make-tree :lhs
 ```
 
 We will adopt the convention that the semantics of a word can be any Lisp object.
-For example, the semantics of the word "1" could be the object 1, and the semantics of "without" could be the function set-di fference.
+For example, the semantics of the word "1" could be the object 1, and the semantics of "without" could be the function `set-difference`.
 The semantics of a tree is formed by taking the semantics of the rule that generated the tree and applying it (as a function) to the semantics of the constituents of the tree.
 Thus, the grammar writer must insure that the semantic component of rules are functions that expect the right number of arguments.
 For example, given the rule
@@ -440,9 +441,9 @@ For example, given the rule
 (NP -> (NP CONJ NP) infix-funcall)
 ```
 
-then the semantics of the phrase "1 to 5 without 3" could be determined by first determining the semantics of"1 to 5" tobe(l 2 3 4 5),of"without"tobe set-`difference`, and of "3" to be (3).
-After these sub-constituents are determined, the rule is applied by calling the function `infix-funcall` with the three arguments (1 2 3 4 5), `set-difference`, and (3).
-Assuming that `infix-funcall` is defined to apply its second argument to the other two arguments, the result will be (1 2 4 5).
+then the semantics of the phrase "1 to 5 without 3" could be determined by first determining the semantics of "1 to 5" to be `(1 2 3 4 5)`, of "without" to be `set-difference`, and of "3" to be `(3)`.
+After these sub-constituents are determined, the rule is applied by calling the function `infix-funcall` with the three arguments `(1 2 3 4 5)`, `set-difference`, and `(3)`.
+Assuming that `infix-funcall` is defined to apply its second argument to the other two arguments, the result will be `(1 2 4 5)`.
 
 This may make more sense if we look at a complete grammar for the CD player problem:
 
@@ -478,10 +479,10 @@ As for the lexical rules, the conjunction "and" translates to the union function
 The numbers "0" to "9" translate to themselves.
 Note that both lexical rules like "`CONJ ->` and" and nonlexical rules like "`NP -> (N P N)`" can have functions as their semantic translations; in the first case, the function will just be returned as the semantic translation, whereas in the second case the function will be applied to the list of constituents.
 
-Only minor changes are needed to pa rse to support this kind of semantic processing.
-As we see in the following, we add a sem argument to extend - parse and arrange to pass the semantic components around properly.
+Only minor changes are needed to `parse` to support this kind of semantic processing.
+As we see in the following, we add a `sem` argument to `extend-parse` and arrange to pass the semantic components around properly.
 When we have gathered all the right-hand-side components, we actually do the function application.
-All changes are marked with ***.
+All changes are marked with `***`.
 We adopt the convention that the semantic value `nil` indicates failure, and we discard all such parses.
 
 ```lisp
@@ -595,12 +596,16 @@ With this new grammar, we can get single interpretations out of most reasonable 
 ```lisp
 > (meanings '(1 to 6 without 3 and 4))
 ((1 2 5 6))
+
 > (meanings '(1 and 3 to 7 and 9 without 5 and 6))
-((13 4 7 9))
+((1 3 4 7 9))
+
 > (meanings '(1 and 3 to 7 and 9 without 5 and 2))
 ((1 3 4 6 7 9 2))
+
 > (meanings '(1 9 8 to 2 0 1))
 ((198 199 200 201))
+
 > (meanings '(1 2 3))
 (123 (123))
 ```
@@ -686,7 +691,7 @@ There are two places where we put the score into trees as we create them, and on
 ```
 
 Again we need some new functions to support this.
-Most important is appl y - scorer, which computes the score for a tree.
+Most important is `apply-scorer`, which computes the score for a tree.
 If the tree is a terminal (a word), then the function just looks up the score associated with that word.
 In this grammar all words have a score of 0, but in a grammar with ambiguous words it would be a good idea to give lower scores for infrequently used senses of ambiguous words.
 If the tree is a nonterminal, then the score is computed in two steps.
@@ -891,7 +896,7 @@ It turns out that, in each case, all the interpretations with positive scores re
 Seeing all the scores in gory detail may be of academic interest, but what we really want is something to pick out the best interpretation.
 The following code is appropriate for many situations.
 It picks the top scorer, if there is a unique one, or queries the user if several interpretations tie for the best score, and it complains if there are no valid parses at all.
-The query-user function may be useful in many applications, but note that meani ng uses it only as a default; a program that had some automatic way of deciding could supply another `tie-breaker` function to meani ng.
+The query-user function may be useful in many applications, but note that `meaning` uses it only as a default; a program that had some automatic way of deciding could supply another `tie-breaker` function to `meaning`.
 
 ```lisp
 (defun meaning (words &optional (tie-breaker #'query-user))
@@ -1015,10 +1020,10 @@ It's up to you to design the grammar, but you should allow input something like 
        (RECORD '(1 3 7) :FROM '1))
 ```
 
-This assumes that the functions play and record take keyword arguments (with defaults) for : `from` and : `to`.
+This assumes that the functions `play` and `record` take keyword arguments (with defaults) for `:from` and `:to`.
 You could also extend the grammar to accommodate an automatic timer, with phrases like "at 3:00."
 
-**Exercise  19.5 [m]** In the definition of `permute`, repeated here, why is the :`test # ' eq needed?`
+**Exercise  19.5 [m]** In the definition of `permute`, repeated here, why is the `:test #'eq` needed?
 
 ```lisp
 (defun permute (bag)
@@ -1121,10 +1126,10 @@ Note that I was careful to exclude such rules in my grammars earlier.
 ```
 
 **Answer 19.5** If it were omitted, then `:test` would default to `#'eql`, and it would be possible to remove the "wrong" element from the list.
-Consider the list (1.0 1.0) in an implementation where floating-point numbers are `eql` but not `eq`.
-if `random-elt` chooses the first 1.0 first, then everything is satisfactory-the result list is the same as the input list.
-However, if `random-elt` chooses the second 1.0, then the second 1.0 will be the first element of the answer, but `remove` will remove the wrong 1.0!
-It will remove the first 1.0, and the final answer will be a list with two pointers to the second 1.0 and none to the first.
+Consider the list `(1.0 1.0)` in an implementation where floating-point numbers are `eql` but not `eq`.
+if `random-elt` chooses the first `1.0` first, then everything is satisfactory - the result list is the same as the input list.
+However, if `random-elt` chooses the second `1.0`, then the second `1.0` will be the first element of the answer, but `remove` will remove the wrong `1.0`!
+It will remove the first `1.0`, and the final answer will be a list with two pointers to the second `1.0` and none to the first.
 In other words, we could have:
 
 ```lisp

--- a/docs/chapter19.md
+++ b/docs/chapter19.md
@@ -14,11 +14,11 @@ Anatural language is a language spoken by people, such as English, German, or Ta
 This is in opposition to artificial languages like Lisp, FORTRAN, or Morse code.
 Natural language processing is an important part of AI because language is intimately connected to thought.
 One measure of this is the number of important books that mention language and thought in the title: in AI, Schank and Colby's *Computer Models of Thought and Language;* in linguistics, Whorf's *Language, Thought, and Reality* (and Chomsky's *Language and Mind;)* in philosophy, Fodor's *The Language of Thought;* and in psychology, Vygotsky's *Thought and Language* and John Anderson's *Language, Memory, and Thought.* Indeed, language is the trait many think of as being the most characteristic of humans.
-Much controversy has been generated over the question of whether animais, especially primates and dolphins, can use and "understand" language.
+Much controversy has been generated over the question of whether animals, especially primates and dolphins, can use and "understand" language.
 Similar controversy surrounds the same question asked of computers.
 
 The study of language has been traditionally separated into two broad classes: syntax, or grammar, and semantics, or meaning.
-Historically, syntax has achieved the most attention, largely because on the surface it is more amenable to formai and semiformal methods.
+Historically, syntax has achieved the most attention, largely because on the surface it is more amenable to formal and semiformal methods.
 Although there is evidence that the boundary between the two is at best fuzzy, we still maintain the distinction for the purposes of these notes.
 We will cover the "easier" part, syntax, first, and then move on to semantics.
 
@@ -442,7 +442,7 @@ For example, given the rule
 
 then the semantics of the phrase "1 to 5 without 3" could be determined by first determining the semantics of"1 to 5" tobe(l 2 3 4 5),of"without"tobe set-`difference`, and of "3" to be (3).
 After these sub-constituents are determined, the rule is applied by calling the function `infix-funcall` with the three arguments (1 2 3 4 5), `set-difference`, and (3).
-Assuming that `infix-funcall` is defined to apply its second argument to the other two arguments, the resuit will be (1 2 4 5).
+Assuming that `infix-funcall` is defined to apply its second argument to the other two arguments, the result will be (1 2 4 5).
 
 This may make more sense if we look at a complete grammar for the CD player problem:
 
@@ -693,7 +693,7 @@ If the tree is a nonterminal, then the score is computed in two steps.
 First, all the scores of the constituents of the tree are added up.
 Then, this is added to a measure for the tree as a whole.
 The rule associated with each tree will have either a number attached to it, which is added to the sum, or a function.
-In the latter case, the function is applied to the tree, and the resuit is added to obtain the final score.
+In the latter case, the function is applied to the tree, and the result is added to obtain the final score.
 As a final special case, if the function returns nil, then we assume it meant to return zero.
 This will simplify the definition of some of the scoring functions.
 
@@ -1122,7 +1122,7 @@ Note that I was careful to exclude such rules in my grammars earlier.
 
 **Answer 19.5** If it were omitted, then `:test` would default to `#'eql`, and it would be possible to remove the "wrong" element from the list.
 Consider the list (1.0 1.0) in an implementation where floating-point numbers are `eql` but not `eq`.
-if `random-elt` chooses the first 1.0 first, then everything is satisfactory-the resuit list is the same as the input list.
+if `random-elt` chooses the first 1.0 first, then everything is satisfactory-the result list is the same as the input list.
 However, if `random-elt` chooses the second 1.0, then the second 1.0 will be the first element of the answer, but `remove` will remove the wrong 1.0!
 It will remove the first 1.0, and the final answer will be a list with two pointers to the second 1.0 and none to the first.
 In other words, we could have:
@@ -1138,7 +1138,7 @@ In other words, we could have:
 (defun permute (bag)
   "Return a random permutation of the bag."
   ;; It is done by converting the bag to a vector, but the
-  ;; resuit is always the same type as the input bag.
+  ;; result is always the same type as the input bag.''
   (let ((bag-copy (replace (make-array (length bag)) bag))
         (bag-type (if (listp bag) 'list (type-of bag))))
     (coerce (permute-vector! bag-copy) bag-type)))

--- a/docs/chapter20.md
+++ b/docs/chapter20.md
@@ -488,7 +488,7 @@ More careful representations of "The girls kissed the girls" include the followi
 
 The first of these says that every girl kisses every other girl.
 The second says the same thing, except that a girl need not kiss herself.
-The third says that every girl kisses and is kissed by at least one other girl, but not necessarily all of them, and the fourth says that everbody is in on at least one kissing.
+The third says that every girl kisses and is kissed by at least one other girl, but not necessarily all of them, and the fourth says that everybody is in on at least one kissing.
 None of these interpretations says anything about who "the girls" are.
 
 Clearly, the predicate calculus representations are less ambiguous than the representation produced by the current system.
@@ -745,7 +745,7 @@ If we simplified this, eliminating the ts and joining ands, we would get the des
         (loves ?m ?w))
 ```
 
-From there, we could use what we know about syntax, in addition to what we know about men, woman, and loving, to determine the most likely final interpretation.
+From there, we could use what we know about syntax, in addition to what we know about men, women, and loving, to determine the most likely final interpretation.
 This will be covered in the next chapter.
 
 ## 20.6 Long-Distance Dependencies
@@ -953,7 +953,7 @@ That is, we will get parses like "spaghetti and (meatballs and salad)" not "(spa
 Still, it can be argued that it is best to produce a single canonical parse, and then let the semantic interpretation functions worry about rearranging the parse in the right order.
 We will not attempt to resolve this debate but will provide the automatic conjunction mechanism as a tool that can be convenient but has no cost for the user who prefers a different solution.
 
-We are now ready to implement the extended DCG rule formalism that handles `:sem, :ex,` and automatie conjunctions.
+We are now ready to implement the extended DCG rule formalism that handles `:sem, :ex,` and automatic conjunctions.
 The function `make-augmented-dcg,` stored under the arrow `==>`, will be used to implement the formalism:
 
 ```lisp

--- a/docs/chapter20.md
+++ b/docs/chapter20.md
@@ -916,7 +916,7 @@ Consider the rule that says that a sentence can consist of two sentences joined 
 ```
 
 While this rule is correct as a declarative statement, it will run into difficulty when run by the standard top-down depth-first DCG interpretation process.
-The top-level goal of parsing an `S` will lead immediately to the subgoal of parsing an `S`, and the resuit will be an infinite loop.
+The top-level goal of parsing an `S` will lead immediately to the subgoal of parsing an `S`, and the result will be an infinite loop.
 
 Fortunately, we know how to avoid this kind of infinite loop: split the offending predicate, `S`, into two predicates: one that supports the recursion, and one that is at a lower level.
 We will call the lower-level predicate `S_`.

--- a/docs/chapter20.md
+++ b/docs/chapter20.md
@@ -262,8 +262,8 @@ Here's the `rule` macro:
   (funcall (get arrow 'rule-function) head body))
 ```
 
-As an example of a rule function, the arrow : - will be used to represent normal Prolog clauses.
-That is, the form (`rule`*head : - body*) will be equivalent to (<- *head body).*
+As an example of a rule function, the arrow `:-` will be used to represent normal Prolog clauses.
+That is, the form (`rule` *head :- body*) will be equivalent to `(<-` *head body).*
 
 ```lisp
 (setf (get ':- 'rule-function)
@@ -347,7 +347,7 @@ The function `make-dcg` inserts variables to keep track of the strings that are 
                (make-dcg-body (rest body) (+ n 1))))))))
 ```
 
-**Exercise  20.1 [m]**`make-dcg` violates one of the cardinal rules of macros.
+**Exercise  20.1 [m]** `make-dcg` violates one of the cardinal rules of macros.
 What does it do wrong?
 How would you fix it?
 

--- a/docs/chapter20.md
+++ b/docs/chapter20.md
@@ -526,9 +526,9 @@ They must come from the determiners, "every" and "a." Also, it seems that `all` 
 So the determiners will have translations looking like this:
 
 ```lisp
-(rule (Det ?any ?x ?p ?q (the ?x (and ?p ?q)))     --> (:word the))
+(rule (Det ?any ?x ?p ?q (the ?x (and ?p ?q)))   --> (:word the))
 (rule (Det 3sg ?x ?p ?q (exists ?x (and ?p ?q))) --> (:word a))
-(rule (Det 3sg ?x ?p ?q (all ?x (-> ?p ?q)))         --> (:word every))
+(rule (Det 3sg ?x ?p ?q (all ?x (-> ?p ?q)))     --> (:word every))
 ```
 
 Once we have accepted these translations of the determiners, everything else follows.
@@ -643,23 +643,26 @@ With this grammar, we get the following correspondence between sentences and log
 ```lisp
 Every picture paints a story.
 (ALL ?3 (-> (PICTURE ?3)
-                     (EXISTS ?14 (AND (STORY ?14) (PAINT ?3 ?14)))))
+            (EXISTS ?14 (AND (STORY ?14) (PAINT ?3 ?14)))))
+
 Every boy that paints a picture sleeps.
 (ALL ?3 (-> (AND (AND (YOUNG ?3) (MALE ?3) (HUMAN ?3))
-                              (EXISTS ?19 (AND (PICTURE ?19)
-                                                            (PAINT ?3 ?19))))
-                  (SLEEP ?3)))
+                 (EXISTS ?19 (AND (PICTURE ?19)
+                                  (PAINT ?3 ?19))))
+            (SLEEP ?3)))
+
 Every boy that sleeps paints a picture.
 (ALL ?3 (-> (AND (AND (YOUNG ?3) (MALE ?3) (HUMAN ?3))
-                                (SLEEP ?3))
-                    (EXISTS ?22 (AND (PICTURE ?22) (PAINT ?3 ?22)))))
+                 (SLEEP ?3))
+            (EXISTS ?22 (AND (PICTURE ?22) (PAINT ?3 ?22)))))
+
 Every boy that paints a picture that sells
 paints a picture that stinks.
 (ALL ?3 (-> (AND (AND (YOUNG ?3) (MALE ?3) (HUMAN ?3))
-                              (EXISTS ?19 (AND (AND (PICTURE ?19) (SELLS ?19))
-                                                    (PAINT ?3 ?19))))
-                    (EXISTS ?39 (AND (AND (PICTURE ?39) (STINKS ?39))
-                                                  (PAINT ?3 ?39)))))
+                 (EXISTS ?19 (AND (AND (PICTURE ?19) (SELLS ?19))
+                                  (PAINT ?3 ?19))))
+            (EXISTS ?39 (AND (AND (PICTURE ?39) (STINKS ?39))
+                             (PAINT ?3 ?39)))))
 ```
 
 ## 20.5 Preserving Quantifier Scope Ambiguity

--- a/docs/chapter21.md
+++ b/docs/chapter21.md
@@ -510,7 +510,7 @@ The *** indicates no mapping:
 (<- (slot-constituent (?role ?n (P ?particle)) *** ? ?))
 ```
 
-We are now ready to define compi ement.
+We are now ready to define `complement`.
 It takes a slot description, maps it into a constituent, and then calls `XP` to parse that constituent:
 
 ```lisp
@@ -712,7 +712,7 @@ The implementation of these tools is left for the next section; here we show the
 
 The first set of abbreviations defines the agreement features.
 The obvious way to handle agreement is with two features, one for person and one for number.
-So first-person singular might be represented (1 `sing`).
+So first-person singular might be represented `(1 sing)`.
 A problem arises when we want to describe verbs.
 Every verb except "be" makes the distinction only between third- person singular and all the others.
 We don't want to make five separate entries in the lexicon to represent all the others.
@@ -1281,7 +1281,7 @@ This option is only available for categories that are listed in the definition:
 
 ## 21.13 Other Primitives
 
-To support the : `test` predicates made in various grammar rules we need definitions of the Prolog predicates `if, member, =, numberp`, and `atom`.
+To support the `:test` predicates made in various grammar rules we need definitions of the Prolog predicates `if, member, =, numberp`, and `atom`.
 They are repeated here:
 
 ```lisp

--- a/docs/chapter21.md
+++ b/docs/chapter21.md
@@ -714,7 +714,7 @@ The first set of abbreviations defines the agreement features.
 The obvious way to handle agreement is with two features, one for person and one for number.
 So first-person singular might be represented `(1 sing)`.
 A problem arises when we want to describe verbs.
-Every verb except "be" makes the distinction only between third- person singular and all the others.
+Every verb except "be" makes the distinction only between third-person singular and all the others.
 We don't want to make five separate entries in the lexicon to represent all the others.
 One alternative is to have the agreement feature be a set of possible values, so all the others would be a single set of five values rather than five separate values.
 This makes a big difference in cutting down on backtracking.
@@ -1490,7 +1490,3 @@ Contrast this to "The truck, which has 4-wheel drive, costs $5000." Here the rel
 (and (the ?x (truck ?x))
       (4-wheel-drive ?x) (costs ?x $5000))
 ```
-
-Part V
-The Rest of Lisp
-

--- a/docs/chapter22.md
+++ b/docs/chapter22.md
@@ -533,7 +533,7 @@ This also holds for the compiler, as we see in the next section.
 ## 22.3 A Properly Tail-Recursive Interpreter
 
 Unfortunately, the interpreter presented above can not lay claim to the name Scheme, because a true Scheme must be properly tail-recursive.
-Our interpreter is tail- recursive only when run in a Common Lisp that is tail-recursive.
+Our interpreter is tail-recursive only when run in a Common Lisp that is tail-recursive.
 To see the problem, consider the following Scheme procedure:
 
 ```lisp

--- a/docs/chapter22.md
+++ b/docs/chapter22.md
@@ -35,14 +35,14 @@ Lexical variables can be used to implement package-like structures.
 
 9.  Scheme has no special forms for looping; instead it asks the user to use recursion and promises to implement the recursion efficiently.
 
-The five main special forms in Scheme are `quote` and `if`, which are just as in Common Lisp; `begin` and `set!`, which are just different spellings for `progn` and `setq`; and `lambda`, which is as in Common Lisp, except that it doesn't require a # 'before it.
+The five main special forms in Scheme are `quote` and `if`, which are just as in Common Lisp; `begin` and `set!`, which are just different spellings for `progn` and `setq`; and `lambda`, which is as in Common Lisp, except that it doesn't require a `#'` before it.
 In addition, Scheme allows variables, constants (numbers, strings, and characters), and function calls.
 The function call is different because the function itself is evaluated in the same way as the arguments.
 In Common Lisp, (`f x`) means to look up the function binding of `f` and apply that to the value of `x`.
 In Scheme, `(f x)` means to evaluate `f` (in this case by looking up the value of the variable `f` ), evaluate `x` (by looking up the value of the variable in exactly the same way) and then apply the function to the argument.
 Any expression can be in the function position, and it is evaluated just like the arguments.
 Another difference is that Scheme uses `#t` and `#f` for true and false, instead of `t` and `nil`.
-The empty list is denoted by `()`, and it is distinct from the false value, #f.
+The empty list is denoted by `()`, and it is distinct from the false value, `#f`.
 There are also minor lexical differences in the conventions for complex numbers and numbers in different bases, but these can be ignored for all the programs in this book.
 Also, in Scheme a single macro, `define`, serves to define both variables and functions.
 
@@ -577,7 +577,7 @@ The following is a properly tail-recursive interpreter.
 The macro `prog` sets up a `tagbody` within which we can use `go` statements to branch to labels, and it also sets up a `block` from which we can return a value.
 It can also bind variables like `let`, although in this usage, the variable list is empty.
 Any symbol within the body of a `prog` is considered a label.
-In this case, the label : `INTERP` is the target of the branch statements `(GO : INTERP)`.
+In this case, the label `:INTERP` is the target of the branch statements `(GO :INTERP)`.
 I use uppercase to indicate that go-to statements are being used, but this convention has not been widely adopted.
 
 ```lisp
@@ -999,9 +999,8 @@ Once the working of `call/cc` is understood, the implementation is obvious:
 ## 22.6 History and References
 
 Lisp interpreters and AI have a long history together.
-MIT AI Lab Memo No.
-1 ([McCarthy 1958](B9780080571157500285.xhtml#bb0790)) was the first paper on Lisp.
-McCarthy's students were working on a Lisp compiler, had written certain routines-`read`, `print`, etc.-`in` assembly language, and were trying to develop a full Lisp interpreter in assembler.
+MIT AI Lab Memo No. 1 ([McCarthy 1958](B9780080571157500285.xhtml#bb0790)) was the first paper on Lisp.
+McCarthy's students were working on a Lisp compiler, had written certain routines-`read`, `print`, etc. - in assembly language, and were trying to develop a full Lisp interpreter in assembler.
 Sometime around the end of 1958, McCarthy wrote a theoretical paper showing that Lisp was powerful enough to write the universal function, `eval`.
 A programmer on the project, Steve Russell, saw the paper, and, according to McCarthy:
 
@@ -1109,10 +1108,10 @@ The above definition is equivalent to:
 
 Make changes to the interpreter to allow this kind of internal definition.
 
-**Exercise  22.10** Scheme programmers are often disdainful of the `function` or `#`' notation in Common Lisp.
-Is it possible (without changing the compiler) to make Common Lisp accept `(lambda ( ) ... )` instead of `#` ' `(lambda ( ) ... )` and `fn` instead of `#`'`fn?`
+**Exercise 22.10** Scheme programmers are often disdainful of the `function` or `#'` notation in Common Lisp.
+Is it possible (without changing the compiler) to make Common Lisp accept `(lambda ( ) ... )` instead of `#'(lambda () ... )` and `fn` instead of `#'fn`?
 
-**Exercise  22.11 [m]** The top level of the continuation-passing version of `scheme` includes the call: `(interp (read)``nil` #'`print)`.
+**Exercise 22.11 [m]** The top level of the continuation-passing version of `scheme` includes the call: `(interp (read) nil #'print)`.
 Will this always result in some value being printed?
 Or is it possible that the expression read might call some escape function that ignores the value without printing anything?
 
@@ -1138,7 +1137,7 @@ Explain how this would be done both for the first version of the interpreter and
 **Answer 22.3** No.
 `fail` requires continuations with dynamic extent.
 
-**Answer 22.5** We need only modify `extend` - `env` to know about an atomic `vars` list.
+**Answer 22.5** We need only modify `extend-env` to know about an atomic `vars` list.
 While we're at it, we might as well add some error checking:
 
 ```lisp

--- a/docs/chapter23.md
+++ b/docs/chapter23.md
@@ -732,7 +732,7 @@ For example, if we put the same expression inside a `begin` expression, we get s
         RETURN
 ```
 
-What happens here is that `(+ x y)` and `(* x y)`, when compiled in a context where the value is ignored, both resuit in no generated code.
+What happens here is that `(+ x y)` and `(* x y)`, when compiled in a context where the value is ignored, both result in no generated code.
 Thus, the `if` expression reduces to `(if p nil nil)`, which is compiled like `(begin p nil)`, which also generates no code when not evaluated for value, so the final code just references `z`.
 The compiler can only do this optimization because it knows that `+` and `*` are side-effect-free operations.
 Consider what happens when we replace + with `f` :
@@ -2028,7 +2028,7 @@ But to demonstrate that the right solution doesn't always appear the first time,
 Assuming a properly tail-recursive compiler, the modified version will never require more than *O*(log *n*) space, because at each step at least half of the vector is being sorted tail-recursively.
 
 **Answer 23.10** (1) `(defun (funcall fn . args) (apply fn args))` (2) Suppose you changed the piece of code `(+ . numbers)` to `(+ . (map sqrt numbers))`.
-The latter is the same expression as (+ `map sqrt numbers),` which is not the intended resuit at all.
+The latter is the same expression as (+ `map sqrt numbers),` which is not the intended result at all.
 So there would be an arbitrary restriction: the last argument in an apply form would have to be an atom.
 This kind of restriction goes against the grain of Scheme.
 

--- a/docs/chapter23.md
+++ b/docs/chapter23.md
@@ -1779,16 +1779,16 @@ What time and space complexity does it have?
 
 ```lisp
 (define (sort-vector vector test)
-      (define (sort lo hi)
-          (if (>= lo hi)
-                  vector
-                  (let ((pivot (partition vector lo hi)))
-                        (if (> (- hi pivot) (- pivot lo))
-                                  (begin (sort lo pivot)
-                                                      (sort (+ pivot 1) hi))
-                                  (begin (sort (+ pivot 1) hi)
-                                                      (sort lo pivot))))))
-      (sort 0 (- (vector-length vector 1))))
+   (define (sort lo hi)
+     (if (>= lo hi)
+         vector
+         (let ((pivot (partition vector lo hi)))
+            (if (> (- hi pivot) (- pivot lo))
+                 (begin (sort lo pivot)
+                           (sort (+ pivot 1) hi))
+                 (begin (sort (+ pivot 1) hi)
+                           (sort lo pivot))))))
+   (sort 0 (- (vector-length vector 1))))
 ```
 
 The next three exercises describe extensions that are not part of the Scheme standard.

--- a/docs/chapter23.md
+++ b/docs/chapter23.md
@@ -222,9 +222,7 @@ If this environment were called `env`, then `(in-env-p 'f env)` would return `(0
             (lambda ,(rest name) . ,body)))))
 ```
 
-Finally, we have some auxiliary functions to print out the results, to distinguish bet
-ween labels and instructions, and to determine the index of a variable in an environme
-nt.
+Finally, we have some auxiliary functions to print out the results, to distinguish between labels and instructions, and to determine the index of a variable in an environment.
 Scheme functions now are implemented as structures, which must have a field for the code, and one for the environment.
 In addition, we provide a field for the name of the function and for the argument list; these are used only for debugging purposes.
 We'll adopt the convention that the `define` macro sets the function's name field, by calling `name!` (which is not part of standard Scheme).
@@ -1891,7 +1889,7 @@ The other problem is that complex numbers can only have a lowercase `i`, but `re
 ```
 
 With some work we could also eliminate quote.
-Instead of `'x`, we could use `(string->symbol "X" )`, and instead of `'(1 2)`, wecoulduse something like `(list 1 2)`.
+Instead of `'x`, we could use `(string->symbol "X" )`, and instead of `'(1 2)`, we could use something like `(list 1 2)`.
 The problem is in knowing when to reuse the same list.
 Consider:
 

--- a/docs/chapter23.md
+++ b/docs/chapter23.md
@@ -226,7 +226,8 @@ Finally, we have some auxiliary functions to print out the results, to distingui
 ween labels and instructions, and to determine the index of a variable in an environme
 nt.
 Scheme functions now are implemented as structures, which must have a field for the code, and one for the environment.
-In addition, we provide a field for the name of the function and for the argument list; these are used only for debugging purposes, We'll adopt the convention that the `define` macro sets the function's name field, by calling `name` ! (which is not part of standard Scheme).
+In addition, we provide a field for the name of the function and for the argument list; these are used only for debugging purposes.
+We'll adopt the convention that the `define` macro sets the function's name field, by calling `name!` (which is not part of standard Scheme).
 
 ```lisp
 (defun name! (fn name)
@@ -661,7 +662,8 @@ Note I have extended the machine to include instructions for the most common con
 ```
 
 The remaining two functions are more complex.
-First consider `comp-if` . Rather than blindly generating code for the predicate and both branches, we will consider some special cases.
+First consider `comp-if`.
+Rather than blindly generating code for the predicate and both branches, we will consider some special cases.
 First, it is clear that `(if t x y)` can reduce to `x` and `(if nil x y)` can reduce to `y`.
 It is perhaps not as obvious that `(if p x x)` can reduce to `(begin p x)`, or that the comparison of equality between the two branches should be done on the object code, not the source code.
 Once these trivial special cases have been considered, we're left with three more cases: `(if p x nil), (if p nil y),` and `(if p x y)`.
@@ -1636,7 +1638,7 @@ NIL
 (QUASIQUOTE (A (UNQUOTE B) (UNQUOTE-SPLICING C) D))
 ```
 
-The final step is to make quasi quote a macro that expands into the proper sequence of calls to `cons`, `list`, and `append`.
+The final step is to make `quasiquote` a macro that expands into the proper sequence of calls to `cons`, `list`, and `append`.
 The careful reader will keep track of the difference between the form returned by `scheme-read` (something starting with `quasiquote`), the expansion of this form with the Scheme macro `quasiquote` (which is implemented with the Common Lisp function `quasi-q`), and the eventual evaluation of the expansion.
 In an environment where `b` is bound to the number 2 and `c` is bound to the list `(c1 c2)`, we might have:
 
@@ -1878,10 +1880,8 @@ The following routines do this without consing.
 (defun sign-p (char) (find char "+-"))
 ```
 
-Actually, that's not quite good enough, because a Scheme complex number can have multiple signs in it, as in `3.
-4e- 5+6.
-7e+8i`, and it need not have two numbers, as in `3i` or `4+i` or just `+  i`.
-The other problem is that complex numbers can only have a lowercase `i`, but read does not distinguish between the symbols `3+4i` and `3+4I`.
+Actually, that's not quite good enough, because a Scheme complex number can have multiple signs in it, as in `3.4e-5+6.7e+8i`, and it need not have two numbers, as in `3i` or `4+i` or just `+i`.
+The other problem is that complex numbers can only have a lowercase `i`, but `read` does not distinguish between the symbols `3+4i` and `3+4I`.
 
 **Answer 23.4** Yes, it is possible to implement `begin` as a macro:
 
@@ -1930,7 +1930,7 @@ This has the disadvantage (compared to explicit use of many special forms) that 
 It has the advantage that the optimizations will be applied even when the user did not have a special construct in mind.
 Common Lisp attempts to get the advantages of both by allowing implementations to play loose with what they implement as macros and as special forms.
 
-**Answer 23.6** We define the predicate `always` and install it in two places in `comp-if` :
+**Answer 23.6** We define the predicate `always` and install it in two places in `comp-if`:
 
 ```lisp
 (defun always (pred env)

--- a/docs/chapter24.md
+++ b/docs/chapter24.md
@@ -628,7 +628,7 @@ The implementation is:
 (defloop minimizing minimize)
 ```
 
-**Exercise  24.1**`loop` lets us build aggregates (lists, maximums, sums, etc.) over the body of the loop.
+**Exercise  24.1** `loop` lets us build aggregates (lists, maximums, sums, etc.) over the body of the loop.
 Sometimes it is inconvenient to be restricted to a single-loop body.
 For example, we might want a list of all the nonzero elements of a two-dimensional array.
 One way to implement this is with a macro, `with-collection`, that sets up and returns a queue structure that is built by calls to the function `collect`.
@@ -1223,9 +1223,9 @@ Therefore, this is the approach I adopt.
 
 ## 24.7 Exercises
 
-**Exercise  24.2 [m]** The function reduce is a very useful one, especially with the key keyword.
-Write nonrecursive definitions for append and 1 ength using reduce.
-What other common functions can be written with reduce?
+**Exercise  24.2 [m]** The function `reduce` is a very useful one, especially with the `key` keyword.
+Write nonrecursive definitions for `append` and `length` using `reduce`.
+What other common functions can be written with `reduce`?
 
 **Exercise  24.3** The so-called loop keywords are not symbols in the keyword package.
 The preceding code assumes they are all in the current package, but this is not quite right.

--- a/docs/chapter24.md
+++ b/docs/chapter24.md
@@ -19,7 +19,7 @@ Common Lisp uses the package system to help resolve such conflicts.
 Instead of a single symbol table, Common Lisp allows any number of packages.
 The function `read` always uses the current package, which is defined to be the value of the special variable `*package*`.
 By default, Lisp starts out in the `common-lisp-user` package.<a id="tfn24-1"></a><sup>[1](#fn24-1)</sup>
-That means that if we type a new symbol, like `zxv!!!(char) ®!?+qw`, it will be entered into that package.
+That means that if we type a new symbol, like `zxv@!?+qw`, it will be entered into that package.
 Converting a string to a symbol and placing it in a package is called *interning.* It is done automatically by `read`, and can be done by the function `intern` if necessary.
 Name conflicts arise when there is contention for names within the `common-lisp-user` package.
 
@@ -58,8 +58,8 @@ Second, the user can make `emycin` be the current package with `(in-package "EMY
 Third, if we only need part of the functionality of a system, we can import specific symbols into the current package.
 For example, we could call `(import ' emycin:defrule)`.
 From then on, typing `defrule` (in the current package) will refer to `emycin:defrule`.
-Fourth, if we want the full functionality of the system, wecall `(use-package "EMYCIN")`.
-This makes ail the external symbols ofthe `emycin` package accessible in the current package.
+Fourth, if we want the full functionality of the system, we call `(use-package "EMYCIN")`.
+This makes all the external symbols of the `emycin` package accessible in the current package.
 
 While packages help eliminate name conflicts, `import` and `use-package` allow them to reappear.
 The advantage is that there will only be conflicts between external symbols.
@@ -821,7 +821,7 @@ and have the generated code be just what we want:
   (* G3811 G3811))
 ```
 
-You have now learned lesson number one of `once-only` : you know how macros differ from functions when it comes to arguments with side effects, and you now know how to handle this.
+You have now learned lesson number one of `once-only`: you know how macros differ from functions when it comes to arguments with side effects, and you now know how to handle this.
 Lesson number two comes when you try to write (or even understand) a definition of `once-only`-only when you truly understand the nature of macros will you be able to write a correct version.
 As always, the first thing to determine is what a call to `once-only` should expand into.
 The generated code should test the variable to see if it is free of side effects, and if so, generate the body as is; otherwise it should generate code to bind a new variable, and use that variable in the body of the code.

--- a/docs/chapter24.md
+++ b/docs/chapter24.md
@@ -1335,8 +1335,9 @@ The idea is that the comment should help the reader prove the correctness of the
 
 ----------------------
 
+
 <a id="fn24-1"></a><sup>[1](#tfn24-1)</sup>
 Or in the user package in non-ANSI systems.
 
 <a id="fn24-2"></a><sup>[2](#tfn24-2)</sup>
-As was noted before, the proper way to do this is to proclaim squa re as an inline function, not a macro, but please bear with the example.
+As was noted before, the proper way to do this is to proclaim `square` as an inline function, not a macro, but please bear with the example.

--- a/docs/chapter25.md
+++ b/docs/chapter25.md
@@ -154,7 +154,7 @@ One needs to use `#'local-fn` to refer to it.
   (mapcar 'local-fn list))
 ```
 
-**Diagnosis:** If you changed the name of a function, did you change the name every-where?
+**Diagnosis:** If you changed the name of a function, did you change the name everywhere?
 For example, if you decide to change the name of `print-fn` to `print-function` but forget to change the value of `*printer*`, then the old function will be called.
 
 **Remedy:** Use your editor's global replace command.
@@ -1223,8 +1223,8 @@ The programmer must be careful not to use such extensions in portable code.
 
 ## 25.18 Exercises
 
-**Exercise  251 [h]** On your next programming project, keep a log of each bug you detect and its eventual cause and remedy.
-Classify each one according to the taxon-omy given in this chapter.
+**Exercise 25.1 [h]** On your next programming project, keep a log of each bug you detect and its eventual cause and remedy.
+Classify each one according to the taxonomy given in this chapter.
 What kind of mistakes do you make most often?
 How could you correct that?
 

--- a/docs/chapter25.md
+++ b/docs/chapter25.md
@@ -27,7 +27,7 @@ These possibilities can be broken down further into four cases:
 An expression can be incomplete because you have left off a right parenthesis (or inserted an extra left parenthesis).
 Or you may have started a string, atom, or comment without finishing it.
 This is particularly hard to spot when the error spans multiple lines.
-A string begins and ends with double-quotes: `"string"`; an atom containing unusual characters can be delimited by vertical bars: `| AN ATOM |` ; and a comment can be of the form `# | a comment | #`.
+A string begins and ends with double-quotes: `"string"`; an atom containing unusual characters can be delimited by vertical bars: `| AN ATOM |`; and a comment can be of the form `# | a comment | #`.
 Here are four incomplete expressions:
 
 ```lisp
@@ -135,19 +135,19 @@ Consider:
       (reduce #'better values)))
 ```
 
-Now suppose that the definitions of `score - fn, print - fn`, and `better` are all changed.
+Now suppose that the definitions of `score-fn`, `print-fn`, and `better` are all changed.
 Does any of the prior code have to be recompiled?
 The variable *`printer`* can stay as is.
 When it is funcalled, the symbol `print-fn` will be consulted for the current functional value.
-Within show, the expression # ' `better` is compiled into code that will get the current version of `better`, so it too is safe.
-However, the variable *`scorer`* must be changed.
+Within `show`, the expression `#'better` is compiled into code that will get the current version of `better`, so it too is safe.
+However, the variable `*scorer*` must be changed.
 Its value is the old definition of `score-fn`.
 
-**Remedy:** Re-evaluate the definition of *`scorer`*.
+**Remedy:** Re-evaluate the definition of `*scorer*`.
 It is unfortunate, but this problem encourages many programmers to use symbols where they really mean functions.
 Symbols will be coerced to the global function they name when passed to `funcall` or `apply`, but this can be the source of another error.
-In the following example, the symbol `local - fn` will not refer to the locally bound function.
-One needs to use `#'local - fn` to refer to it.
+In the following example, the symbol `local-fn` will not refer to the locally bound function.
+One needs to use `#'local-fn` to refer to it.
 
 ```lisp
 (flet ((local-fn (x) ...))
@@ -155,7 +155,7 @@ One needs to use `#'local - fn` to refer to it.
 ```
 
 **Diagnosis:** If you changed the name of a function, did you change the name every-where?
-For example, if you decide to change the name of `print-fn` to `print-function` but forget to change the value of *`printer`*, then the old function will be called.
+For example, if you decide to change the name of `print-fn` to `print-function` but forget to change the value of `*printer*`, then the old function will be called.
 
 **Remedy:** Use your editor's global replace command.
 To be even safer, redefine obsolete functions to call `error`.
@@ -221,7 +221,7 @@ Let's fix the problem by changing `labels` to `flet` and naming the local functi
 ```
 
 Annoyingly, this version still doesn't work!
-This time, the problem is carelessness; we changed the `replace- ? - vars to recurse` in two places, but not in the two calls in the body of `recurse`.
+This time, the problem is carelessness; we changed the `replace-?-vars` to `recurse` in two places, but not in the two calls in the body of `recurse`.
 
 **Remedy:** In general, the lesson is to make sure you call the right function.
 If there are two functions with similar effects and you call the wrong one, it can be hard to see.
@@ -249,7 +249,8 @@ A list beginning with `lambda` is just that: a list, not a closure.
 Therefore, it cannot capture lexical variables the way a closure does.
 
 **Remedy:** The correct way to create a closure is to evaluate a call to the special form `function`, or its abbreviation, `#'`.
-Here is a replacement for the code beginning with '(`lambda ....` Note that it is a closure, closed over `pred` and `c`.
+Here is a replacement for the code beginning with `'(lambda ....`
+Note that it is a closure, closed over `pred` and `c`.
 Also note that it gets the `predicate` each time it is called; thus, it is safe to use even when predicates are being changed dynamically.
 The previous version would not work when a predicate is changed.
 
@@ -259,8 +260,8 @@ The previous version would not work when a predicate is changed.
           (funcall (get c 'predicate) obj)))
 ```
 
-It is important to remember that `function` (and thus # ') is a special form, and thus only returns the right value when it is evaluated.
-A common error is to use # ' notation in positions that are not evaluated:
+It is important to remember that `function` (and thus `#'`) is a special form, and thus only returns the right value when it is evaluated.
+A common error is to use `#'` notation in positions that are not evaluated:
 
 ```lisp
 (defvar *obscure-fns* '(#'cis #'cosh #'ash #'bit-orc2)) ; *wrong*
@@ -277,11 +278,11 @@ The first assures that each function special form is evaluated, and the second u
 (defvar *obscure-fns* '(cis cosh ash bit-orc2))
 ```
 
-Another common `error` is to expect # ' `if` or # ' `or` to return a function.
+Another common `error` is to expect `#'if` or `#'or` to return a function.
 This is an error because special forms are just syntactic markers.
 There is no function named `if` or `or`; they should be thought of as directives that tell the compiler what to do with a piece of code.
 
-By the way, the function `make` - `specialization` above is bad not only for its lack of `function` but also for its use of backquote.
+By the way, the function `make-specialization` above is bad not only for its lack of `function` but also for its use of backquote.
 The following is a better use of backquote:
 
 ```lisp
@@ -380,7 +381,7 @@ Suppose I had:
     ...)
 ```
 
-Now, if I become curious as to what `mv -1` returns, I might change this code to:
+Now, if I become curious as to what `mv-1` returns, I might change this code to:
 
 ```lisp
 (multiple-value-bind (a b c)
@@ -426,7 +427,7 @@ It runs in under a second on a SPARCstation, which is slower than optimized C, b
       (setf (aref arr i j) 0.0))))
 ```
 
-Another common error is to use something like (`simple-vector fixnum`) asatype specifier.
+Another common error is to use something like `(simple-vector fixnum)` as a type specifier.
 It is a quirk of Common Lisp that the `simple-vector` type specifier only accepts a size, not a type, while the `array, vector` and `simple-array` specifiers all accept an optional type followed by an optional size or list of sizes.
 To specify a simple vector of fixnums, use (`simple-array fixnum (*)`).
 
@@ -434,7 +435,7 @@ To be precise, `simple-vector` means (`simple-array t (*)`).
 This means that `simple-vector` cannot be used in conjunction with any other type specifier.
 A common mistake is to think that the type (`and simple-vector (vector fixnum)`) is equivalent to (`simple-array fixnum (*)`), a simple, one-dimensional vector of fixnums.
 Actually, it is equivalent to (`simple-array t (*)`), a simple one-dimensional array of any type elements.
-To eliminate this problem, avoid `simple- vector` altogether.
+To eliminate this problem, avoid `simple-vector` altogether.
 
 ## 25.8 My Lisp Does the Wrong Thing
 
@@ -442,7 +443,7 @@ When all else fails, it is tempting to shift the blame for an error away from yo
 It is certainly true that errors are found in existing implementations.
 But it is also true that most of the time, Common Lisp is merely doing something the user did not expect rather than something that is in error.
 
-For example, a common "bug report" is to complain about read - `from- string`.
+For example, a common "bug report" is to complain about `read-from-string`.
 A user might write:
 
 ```lisp
@@ -451,15 +452,15 @@ A user might write:
 
 expecting the expression to start reading at position `2` and thus return `b`.
 In fact, this expression returns a.
-The angry user thinks the implementation has erroneously ignored the :`start` argument and files a bug report,<a id="tfn25-1"></a><sup>[1](#fn25-1)</sup> only to get back the following explanation:
+The angry user thinks the implementation has erroneously ignored the `:start` argument and files a bug report,<a id="tfn25-1"></a><sup>[1](#fn25-1)</sup> only to get back the following explanation:
 
 The function `read-from-string` takes two optional arguments, `eof-errorp` and `eof-value`, in addition to the keyword arguments.
-Thus, in the expression above, : `start` is taken as the value of `eof-errorp`, with `2` as the value of `eof-value`.
+Thus, in the expression above, `:start` is taken as the value of `eof-errorp`, with `2` as the value of `eof-value`.
 The correct answer is in fact to read from the start of the string and return the very first form, a.
 
 The functions `read-from-string` and `parse-namestring` are the only built-in functions that have this problem, because they are the only ones that have both optional and keyword arguments, with an even number of optional arguments.
 The functions `write-line` and `write-string` have keyword arguments and a single optional argument (the stream), so if the stream is accidently omitted, an error will be signaled.
-(If you type (`write-line str :start 4`), the system will complain either that : `start` is not a stream or that 4 is not a keyword.)
+(If you type (`write-line str :start 4`), the system will complain either that `:start` is not a stream or that 4 is not a keyword.)
 
 The moral is this: functions that have both optional and keyword arguments are confusing.
 Take care when using existing functions that have this problem, and abstain from using both in your own functions.
@@ -601,7 +602,7 @@ One recent book on AI programming suggests the following:
 
 The only possible reason for this macro is an unfounded desire for efficiency.
 Always use an `inline` function instead of a macro for such cases.
-That way you get the efficiency gain, you have not introduced a spurious macro, and you gain the ability to `apply` or `map` the function # ' `binding - of`, something you could not do with a macro:
+That way you get the efficiency gain, you have not introduced a spurious macro, and you gain the ability to `apply` or `map` the function `#'binding-of`, something you could not do with a macro:
 
 ```lisp
 (proclaim '(inline binding-of))
@@ -632,7 +633,7 @@ For example, here is the syntax of a macro to iterate over the leaves of a tree 
 
 There are a number of things to watch out for in figuring out how to expand a macro.
 First, make sure you don't shadow local variables.
-Consider the following definition for `pop - end`, a function to pop off and return the last element of a list, while updating the list to no longer contain the last element.
+Consider the following definition for `pop-end`, a function to pop off and return the last element of a list, while updating the list to no longer contain the last element.
 The definition uses `last1`, which was defined on page 305 to return the last element of a list, and the built-in function `nbutlast` returns all but the last element of a list, destructively altering the list.
 
 ```lisp
@@ -753,10 +754,10 @@ The five values are: (1) a list of temporary, local variables used in the code; 
 This is necessary for variations of `setf` like `inef` and `pop`, which need to both access and store.
 
 In the following `setf` method for `last`, then, we are defining the meaning of (`setf` (`last place`) `value`).
-We keep track of all the variables and values needed to evaluate `place`, and add to that three more local variables: `last2`-var will hold the last two elements of the list, `last2`-p will be true only if there are two or more elements in the list, and `last-var` will hold the form to access the last element of the list.
+We keep track of all the variables and values needed to evaluate `place`, and add to that three more local variables: `last2-var` will hold the last two elements of the list, `last2-p` will be true only if there are two or more elements in the list, and `last-var` will hold the form to access the last element of the list.
 We also make up a new variable, `result`, to hold the `value`.
 The code to store the value either modifies the cdr of `last2-var`, if the list is long enough, or it stores directly into `place`.
-The code to access the value just retrieves `last - var`.
+The code to access the value just retrieves `last-var`.
 
 ```lisp
 (define-setf-method last (place)
@@ -866,11 +867,9 @@ If by this the beginner wants a macro that just *does* two things, the answer is
 There will be no efficiency problem, even if the progn forms are nested.
 That is, if macro-expansion results in code like:
 
-```lisp
-(progn (progn (progn *a b*) c) (progn *d e))*
-```
+> `(progn (progn (progn` *a b) c*) `(progn` *d e*))
 
-the compiler will treat it the same as `(progn *abc de).*`
+the compiler will treat it the same as `(progn` *a b c d e).*
 
 On the other hand, if the beginner wants a macro that *returns* two values, the proper form is `values`, but it must be understood that the calling function needs to arrange specially to see both values.
 There is no way around this limitation.
@@ -976,7 +975,7 @@ Use parser: `print-tree` instead of `parser-print-tree`.
 A variable named `last-node` could have two meanings; use `previous` -`node` or `final` - `node` instead.
 
 14.  A name like `propagate-constraints-to-neighboring-vertexes` is too long, while `prp-con` is too short.
-In deciding on length, consider how the name will be used: `propagate-constraints` is just right, because a typical call will be `(propagate-const rai nts vertex)`, so it will be obvious what the constraints are propagating to.
+In deciding on length, consider how the name will be used: `propagate-constraints` is just right, because a typical call will be `(propagate-constraints vertex)`, so it will be obvious what the constraints are propagating to.
 
 ### Deciding on the Order of Parameters
 
@@ -1034,7 +1033,7 @@ We will soon create the `project-x package`, and it will be used in all subseque
 5.  We want to define the Project-X system as a collection of files.
 Unfortunately, Common Lisp provides no way to do that, so we have to load our own system-definition functions explicitly with a call to `load`.
 
-6.  The call to `define - system` specifies the files that make up Project-X.
+6.  The call to `define-system` specifies the files that make up Project-X.
 We provide a name for the system, a directory for the source and object files, and a list of *modules* that make up the system.
 Each module is a list consisting of the module name (a symbol) followed by a one or more files (strings or pathnames).
 We have used keywords as the module names to eliminate any possible name conflicts, but any symbol could be used.
@@ -1079,13 +1078,13 @@ Now we need to provide the system-definition functions, `define-system` and `mak
 The idea is that `define-system` is used to define the files that make up a system, the modules that the system is comprised of, and the files that make up each module.
 It is necessary to group files into modules because some files may depend on others.
 For example, all macros, special variables, constants, and inline functions need to be both compiled and loaded before any other files that reference them are compiled.
-In Project-X, all `defvar, defparameter, defconstant,` and `defstruct`<a id="tfn25-3"></a><sup>[3](#fn25-3)</sup> forms are put in the file header, and all defmacro forms are put in the file macros.
-Together these two files form the first module, named : macros, which will be loaded before the other two modules (: `main` and :`windows`) are compiled and loaded.
+In Project-X, all `defvar, defparameter, defconstant,` and `defstruct`<a id="tfn25-3"></a><sup>[3](#fn25-3)</sup> forms are put in the file header, and all `defmacro` forms are put in the file `macros`.
+Together these two files form the first module, named `:macros`, which will be loaded before the other two modules (`:main` and `:windows`) are compiled and loaded.
 
-define-system also provides a place to specify a directory where the source and object files will reside.
-For larger systems spread across multiple directories, `define - system` will not be adequate.
+`define-system` also provides a place to specify a directory where the source and object files will reside.
+For larger systems spread across multiple directories, `define-system` will not be adequate.
 
-Here is the first part of the file `defsys.lisp`, showing the definition of `define-system` and the structure sys.
+Here is the first part of the file `defsys.lisp`, showing the definition of `define-system` and the structure `sys`.
 
 ```lisp
 ;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: User -*-
@@ -1114,11 +1113,11 @@ and add the new one.`
 name)
 ```
 
-The function `make` - `systemis` used to compile and/or load a previously defined system.
+The function `make-system` is used to compile and/or load a previously defined system.
 The name supplied is used to look up the definition of a system, and one of three actions is taken on the system.
-The keyword : `cload` means to compile and then load files.
-: `load` means to load files; if there is an object (compiled) file and it is newer than the source file, then it will be loaded, otherwise the source file will be loaded.
-Finally, : `update` means to compile just those source files that have been changed since their corresponding source files were last altered, and to load the new compiled version.
+The keyword `:cload` means to compile and then load files.
+`:load` means to load files; if there is an object (compiled) file and it is newer than the source file, then it will be loaded, otherwise the source file will be loaded.
+Finally, `:update` means to compile just those source files that have been changed since their corresponding source files were last altered, and to load the new compiled version.
 
 ```lisp
 (defun make-system (&key (module : al 1 ) (action :cload)
@@ -1194,8 +1193,8 @@ An implementation would be within its right to return 1, or any other number or 
 An unsuspecting programmer may code an expression that is an error but still computes reasonable results in his or her implementation.
 A common example is applying get to a non-symbol.
 This is an error, but many implementations will just return nil, so the programmer may write (`get x ' prop`) when `(if ( symbol p x) (get x 'prop) nil`) is actually needed for portable code.
-Another common problem is with subseq and the sequence functions that take : end keywords.
-It is an error if the : end parameter is not an integer less than the length of the sequence, but many implementations will not complain if : end is nil or is an integer greater than the length of the sequence.
+Another common problem is with subseq and the sequence functions that take `:end` keywords.
+It is an error if the `:end` parameter is not an integer less than the length of the sequence, but many implementations will not complain if `:end` is nil or is an integer greater than the length of the sequence.
 
 The Common Lisp specification often places constraints on the result that a function must compute, without fully specifying the result.
 For example, both of the following are valid results:

--- a/docs/chapter25.md
+++ b/docs/chapter25.md
@@ -483,10 +483,10 @@ But I can turn to Lisp itself and ask:
 
 ```lisp
 > (apropos "push")
-PUSH                              Macro          (VALUE PLACE), plist
-PUSHNEW                        Macro          (VALUE PLACE &KEY ...), plist
-VECTOR-PUSH                function    (NEW-ELEMENT VECTOR), plist
-VECTOR-PUSH-EXTEND  function    (DATA VECTOR &OPTIONAL ...), plist
+PUSH               Macro     (VALUE PLACE), plist
+PUSHNEW            Macro     (VALUE PLACE &KEY ...), plist
+VECTOR-PUSH        function  (NEW-ELEMENT VECTOR), plist
+VECTOR-PUSH-EXTEND function  (DATA VECTOR &OPTIONAL ...), plist
 ```
 
 This should be enough to remind me that `vector-push` is the answer.
@@ -783,23 +783,23 @@ The code to access the value just retrieves `last - var`.
 It should be mentioned that `setf` methods are very useful and powerful things.
 It is often better to provide a `setf` method for an arbitrary function, `f`, than to define a special setting function, say, `set-f`.
 The advantage of the `setf` method is that it can be used in idioms like `incf` and `pop`, in addition to `setf` itself.
-Also, in ANSI Common Lisp, it is permissible to name a function with # ' (`setf f`), so you can also use map or apply the `setf` method.
+Also, in ANSI Common Lisp, it is permissible to name a function with `#'(setf f)`, so you can also use map or apply the `setf` method.
 Most `setf` methods are for functions that just access data, but it is permissible to define `setf` methods for functions that do any computation whatsoever.
 As a rather fanciful example, here is a `setf` method for the square-root function.
 It makes (`setf (sqrt x) 5`) be almost equivalent to (`setf x (* 5 5)`) ; the difference is that the first returns 5 while the second returns 25.
 
 ```lisp
 (define-setf-method sqrt (num)
-  (multiple-value-bind (temps vals stores store-form access-form)
-        (get-setf-method num)
-    (let ((store (gensym)))
-        (values temps
-                    vals
-                    (list store)
-                    '(let ((,(first stores) (* .store .store)))
-                        ,store-form
-                        ,store)
-                    '(sqrt .access-form)))))
+ (multiple-value-bind (temps vals stores store-form access-form)
+    (get-setf-method num)
+  (let ((store (gensym)))
+    (values temps
+          vals
+          (list store)
+          '(let ((,(first stores) (* .store .store)))
+            ,store-form
+            ,store)
+          '(sqrt .access-form)))))
 ```
 
 Turning from `setf` methods back to macros, another hard part about writing portable macros is anticipating what compilers might warn about.

--- a/docs/chapter3.md
+++ b/docs/chapter3.md
@@ -1218,7 +1218,7 @@ There are quite a few other numeric functions that have been omitted.
 | `(> 100 99)`   | => `t`   | greater than (also `>=`, greater than or equal to)             |
 | `(= 100 100)`  | => `t`   | equal (also `/=`, not equal)                                   |
 | `(< 99 100)`   | => `t`   | less than (also `<=`, less than or equal to)                   |
-| `(random 100)` | `=> 42`  | random integer from 0 to 99                                    |
+| `(random 100)` | => `42`  | random integer from 0 to 99                                    |
 | `(expt 4 2)`   | => `16`  | exponentiation (also exp, *e<sup>x</sup>* and `log`)           |
 | `(sin pi)`     | => `0.0` | sine function (also `cos`, `tan,` etc.)                        |
 | `(asin 0)`     | => `0.0` | arcsine or sin<sup>-1</sup> function (also `acos, atan`, etc.) |
@@ -1226,7 +1226,7 @@ There are quite a few other numeric functions that have been omitted.
 | `(abs -3)`     | => `3`   | absolute value                                                 |
 | `(sqrt 4)`     | => `2`   | square root                                                    |
 | `(round 4.1)`  | => `4`   | round off (also `truncate, floor, ceiling`)                    |
-| `(rem 11 5)`   | => 1     | remainder (also `mod`)                                         |
+| `(rem 11 5)`   | => `1`   | remainder (also `mod`)                                         |
 
 ## 3.9 Functions on Sets
 

--- a/docs/chapter4.md
+++ b/docs/chapter4.md
@@ -1013,7 +1013,7 @@ We wanted GPS to return a list of the actions executed.
 However, in order to account for the case where the goal can be achieved with no action, I included `(START)` in the value returned by GPS.
 These examples include the `START` and `EXECUTING` forms but also a list of the form (AT *n*), for some *n*.
 This is the bug.
-If we go back and look at the function GPS, we find that it reports the resuit by removing all atoms from the state returned by `achieve-all`.
+If we go back and look at the function GPS, we find that it reports the result by removing all atoms from the state returned by `achieve-all`.
 This is a "pun"-we said remove atoms, when we really meant to remove all conditions except the `(START)` and `(EXECUTING *action*)` forms.
 Up to now, all these conditions were atoms, so this approach worked.
 The maze domain introduced conditions of the form (`AT` *n*), so for the first time there was a problem.

--- a/docs/chapter4.md
+++ b/docs/chapter4.md
@@ -511,7 +511,7 @@ The function `dbg` provides this capability.
 `dbg` prints output in the same way as `format`, but it will only print when debugging output is desired.
 Each call to `dbg` is accompanied by an identifier that is used to specify a class of debugging messages.
 The functions `debug` and `undebug` are used to add or remove message classes to the list of classes that should be printed.
-In this chapter, all the debugging output will use the identifier :`gps`.
+In this chapter, all the debugging output will use the identifier `:gps`.
 Other programs will use other identifiers, and a complex program will use many identifiers.
 
 A call to `dbg` will result in output if the first argument to `dbg`, the identifier, is one that was specified in a call to `debug`.
@@ -521,7 +521,7 @@ In other words, we will write functions that include calls to `dbg` like:
 ```lisp
 (dbg :gps "The current goal is: ~a" goal)
 ```
-If we have turned on debugging with `(debug :gps)`, then calls to dbg with the identifier :`gps` will print output.
+If we have turned on debugging with `(debug :gps)`, then calls to `dbg` with the identifier `:gps` will print output.
 The output is turned off with `(undebug :gps)`.
 `debug` and `undebug` are designed to be similar to `trace` and `untrace`, in that they turn diagnostic output on and off.
 They also follow the convention that `debug` with no arguments returns the current list of identifiers, and that `undebug` with no arguments turns all debugging off.

--- a/docs/chapter8.md
+++ b/docs/chapter8.md
@@ -956,7 +956,7 @@ Implement this approach.
 **Exercise 8.6 [d]** A more complicated approach is to try to decide which ways of breaking up the original expression are promising and which are not.
 Derive some heuristics for making this division, and reimplement `integrate` to include a search component, using the search tools of [chapter 6](B9780080571157500066.xhtml).
 
-Look in a calculus textbook to see how &int;*sin<sup>2</sup>(x)dx is evaluated by two integrations by parts and a division.
+Look in a calculus textbook to see how &int;sin<sup>2</sup>*(x)dx* is evaluated by two integrations by parts and a division.
 Implement this technique as well.
 
 **Exercise 8.7 [m]** Write simplification rules for predicate calculus expressions.

--- a/docs/chapter9.md
+++ b/docs/chapter9.md
@@ -233,7 +233,7 @@ First, a call to (`fib 5`) with `fib` traced:
 8
 ```
 
-We see that (`fib 5`) and (`fib 4`) are each computed once, but (`fib 3`) is computed twice, (`fib 2`) three times,and (`fib 1`) five times.
+We see that (`fib 5`) and (`fib 4`) are each computed once, but (`fib 3`) is computed twice, (`fib 2`) three times, and (`fib 1`) five times.
 Below we call (`memoize 'fib`) and repeat the calculation.
 This time, each computation is done only once.
 Furthermore, when the computation of (`fib 5`) is repeated, the answer is returned immediately with no intermediate computation, and a further call to (`fib 6`) can make use of the value of (`fib 5`).
@@ -1090,7 +1090,7 @@ The function `time:microsecond-time-difference` is used to compare two of these 
 In the code below, I use the conditional read macro characters `#+`and `#-` to define the right behavior on both Explorer and non-Explorer machines.
 We have seeen that `#` is a special character to the reader that takes different action depending on the following character.
 For example, `#'fn` is read as `(function fn)`.
-The character sequence `#+`is defined so that `#+`*feature expression* reads as *expression* if the *feature* is defined in the current implementation, and as nothing at all if it is not.
+The character sequence `#+` is defined so that `#+`*feature expression* reads as *expression* if the *feature* is defined in the current implementation, and as nothing at all if it is not.
 The sequence `#-` acts in just the opposite way.
 For example, on a TI Explorer, we would get the following:
 
@@ -1816,7 +1816,7 @@ The function should take as argument a function representing a strategy for play
 Read the definition of the function `random` and describe how a player could cheat.
 Then describe a countermeasure.
 
-**Exercise 9.10 [m]** On [Page 292](B9780080571157500091.xhtml#p292) we saw the use of the read-time conditionals, #+and #-, where #+is the read-time equivalent of when, and #- is the read-time equivalent of unless.
+**Exercise 9.10 [m]** On [Page 292](B9780080571157500091.xhtml#p292) we saw the use of the read-time conditionals, `#+` and `#-`, where `#+` is the read-time equivalent of when, and `#-` is the read-time equivalent of unless.
 Unfortunately, there is no read-time equivalent of case.
 Implement one.
 

--- a/docs/chapter9.md
+++ b/docs/chapter9.md
@@ -1923,7 +1923,7 @@ What happens if you change the order of the loss clauses in `win` and/or `nim?`
 **Answer 9.6** We start by defining a function, `moves`, which generates all possible moves from a given position.
 This is done by considering each pile of *n* tokens within a set of piles *s*.
 Any pile bigger than two tokens can be split.
-We take care to elimina te duplicate positions by sorting each set of piles, and then removing the duplicates.
+We take care to eliminate duplicate positions by sorting each set of piles, and then removing the duplicates.
 
 ```lisp
 (defun moves (s)


### PR DESCRIPTION
Last year, I generated an ebook, skimmed it on my tablet, and cringed at the number of errors I found quickly, and took notes. I worked on this branch then forgot it for a while. (I think merge conflicts with the footnotes PR tripped me up.) 

This is based on, and includes everything in, #140 . This was to avoid merge conflicts; there isn't an important distinction between the two, so @norvig, feel free to close that one if you haven't started reviewing it already. 