### PR TITLE
Included missing parenthesis

### DIFF
--- a/docs/chapter1.md
+++ b/docs/chapter1.md
@@ -826,7 +826,7 @@ Similarly, the notation `#'f` is an abbreviation for the special form expression
 
 (setf p 'John) => JOHN
 
-defun twice (x) (+ x x)) => TWICE
+(defun twice (x) (+ x x)) => TWICE
 
 (if (= 2 3) (error) (+ 5 6)) => 11
 ```


### PR DESCRIPTION
Section 1.9 Summary was missing the beginning parenthesis in the third note of lisp examples