### PR TITLE
README.md: Include link to scan of the 4th edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Intelligence Programming: Case Studies in Common Lisp* by Peter Norvig (1992), a
 
 The book is available in these formats:
 
-* pdf: [see releases](https://github.com/norvig/paip-lisp/releases/tag/v1.0) for a scanned version
+* pdf, 4th edition: [see releases](https://github.com/norvig/paip-lisp/releases/tag/v1.2) (this is a better scan than that of the 6th edition)
+* pdf, 6th edition: [see releases](https://github.com/norvig/paip-lisp/releases/tag/v1.0)
 * text: [PAIP.txt](https://github.com/norvig/paip-lisp/blob/master/PAIP.txt) (from OCR'ing the scanned pdf, containing many errors)
 * epub: [see releases](https://github.com/norvig/paip-lisp/releases/tag/1.1) for a cleaned up version downloaded from Safari (much cleaner than the scanned versions)
 * and `chapter?.md` markdown files:


### PR DESCRIPTION
Still include a link to the scan of the 6th edition, since that's a newer printing
of the book, and some readers may prefer that.