### PR TITLE
Fixup links to chapters

### DIFF
--- a/docs/chapter1.md
+++ b/docs/chapter1.md
@@ -978,7 +978,7 @@ In Lisp, one `sort` fits all.
 One way to appreciate this kind of flexibility is to see how hard it is to achieve in other languages.
 It is impossible in Pascal; in fact, the language Modula was invented primarily to fix this problem in Pascal.
 The language Ada was designed to allow flexible generic functions, and a book by Musser and Stepanov (1989) describes an Ada package that gives some of the functionality of Common Lisp's sequence functions.
-But the Ada solution is less than ideal: it takes a 264-page book to duplicate only part of the functionality of the 20-page chapter 14 from Steele (1990), and Musser and Stepanov went through five Ada compilers before they found one that would correctly compile their package.
+But the Ada solution is less than ideal: it takes a 264-page book to duplicate only part of the functionality of the 20-page chapter 14 from [Steele (1990)](bibliography.md#bb1160), and Musser and Stepanov went through five Ada compilers before they found one that would correctly compile their package.
 Also, their package is considerably less powerful, since it does not handle vectors or optional keyword parameters.
 In Common Lisp, all this functionality comes for free, and it is easy to add more.
 On the other hand, dynamic typing means that some errors will go undetected until run time.

--- a/docs/chapter10.md
+++ b/docs/chapter10.md
@@ -61,7 +61,7 @@ Other quantities that can be optimized are `compilation-speed, space` and in ANS
 Quantities can be given a number from 0 to 3 indicating how important they are; 3 is most important and is the default if the number is left out.
 
 The (`inline square`) declaration allows the compiler to generate the multiplication specified by `square` right in the loop, without explicitly making a function call to square.
-The compiler will create a local variable for (`svref vect i`) and will not execute the reference twice-inline functions do not have any of the problems associated with macros as discussed on [page 853](B9780080571157500248.xhtml#p853).
+The compiler will create a local variable for (`svref vect i`) and will not execute the reference twice-inline functions do not have any of the problems associated with macros as discussed on [page 853](chapter24.md#p853).
 However, there is one drawback: when you redefine an inline function, you may need to recompile all the functions that call it.
 
 You should declare a function `inline` when it is short and the function-calling overhead will thus be a significant part of the total execution time.
@@ -291,7 +291,7 @@ The choice paid off when `I` wanted a function to choose a random character from
 ```
 
 This example was simple, but in more complicated cases you can make your sequence functions more efficient by having them explicitly check if their arguments are lists or vectors.
-See the definition of `map-into` on [page 857](B9780080571157500248.xhtml#p857).
+See the definition of `map-into` on [page 857](chapter24.md#p857).
 
 ## 10.3 Avoid Complex Argument Lists
 
@@ -325,7 +325,7 @@ We can see what these compile into for the TI Explorer, but remember that your c
 ```
 
 With the regular argument list, we just push the four variables on the argument stack and branch to the list function.
-([Chapter 22](B9780080571157500224.xhtml) explains why a tail-recursive call is just a branch statement.)
+([Chapter 22](chapter22.md) explains why a tail-recursive call is just a branch statement.)
 
 With a rest argument, things are almost as easy.
 It turns out that on this machine, the microcode for the calling sequence automatically handles rest arguments, storing them in local variable 0.
@@ -580,7 +580,7 @@ Or use vectors instead of lists, and reuse values rather than creating copies.
 As usual, this gain in efficiency may lead to errors that can be difficult to debug.
 However, the most common kind of unnecessary copying can be eliminated by simple reorganization of your code.
 Consider the following version of `flatten`, which returns a list of all the atoms in its input, preserving order.
-Unlike the version in [chapter 5](B9780080571157500054.xhtml), this version returns a single list of atoms, with no embedded lists.
+Unlike the version in [chapter 5](chapter5.md), this version returns a single list of atoms, with no embedded lists.
 
 ```lisp
 (defun flatten (input)
@@ -627,7 +627,7 @@ This is to be avoided, and it may be that reverse is actually faster than nrever
 To decide what works best on your particular system, design some test cases and time them.
 
 As an example of efficient use of storage, here is a version of `pat-match` that eliminates (almost) all consing.
-The original version of `pat-match,` as used in ELIZA ([page 180](B9780080571157500066.xhtml#p180)), used an association list of variable/value pairs to represent the binding list.
+The original version of `pat-match,` as used in ELIZA ([page 180](chapter6.md#p180)), used an association list of variable/value pairs to represent the binding list.
 This version uses two sequences: a sequence of variables and a sequence of values.
 The sequences are implemented as vectors instead of lists.
 In general, vectors take half as much space as lists to store the same information, since half of every list is just pointing to the next element.
@@ -705,7 +705,7 @@ It will cons when `vector-push-extend` runs out of space, or when the user needs
 
 Here is the new definition of `pat-match.` It is implemented by closing the definition of `pat-match` and its two auxiliary functions inside a `let` that establishes the bindings of `vars, vals`, and `success`, but that is not crucial.
 Those three variables could have been implemented as global variables instead.
-Note that it does not support segment variables, or any of the other options implemented in the `pat-match` of [chapter 6](B9780080571157500066.xhtml).
+Note that it does not support segment variables, or any of the other options implemented in the `pat-match` of [chapter 6](chapter6.md).
 
 ```lisp
 (let* ((vars (make-array 10 :fill-pointer 0 :adjustable t))
@@ -1277,7 +1277,7 @@ Maintaining the identity of this string is crucial; if, for example, you recompi
 " in the existing trie.
 
 *Artificial Intelligence Programming* ([Charniak et al.
-1987](B9780080571157500285.xhtml#bb0180)) discusses variations on the trie, particularly in the indexing scheme.
+1987](bibliography.md#bb0180)) discusses variations on the trie, particularly in the indexing scheme.
 If we always use proper lists (no non-null `cdrs`), then a more efficient encoding is possible.
 As usual, the best type of indexing depends on the data to be indexed.
 It should be noted that Charniak et al.
@@ -1306,7 +1306,7 @@ In contrast, fetching with the pattern `??llow` is much less efficient.
 The table lookup function would have to search all 26 top-level branches, and for each of those consider all possible second letters, and for each of those consider the path `llow`.
 Quite a bit of searching is required before arriving at the complete set of matches: bellow, billow, fallow, fellow, follow, hallow, hollow, mallow, mellow, pillow, sallow, tallow, wallow, willow, and yellow.
 
-We will return to the problem of discrimination nets with variables in [section 14.8](B9780080571157500145.xhtml#s0040), [page 472](B9780080571157500145.xhtml#p472).
+We will return to the problem of discrimination nets with variables in [section 14.8](chapter14.md#s0040), [page 472](chapter14.md#p472).
 
 ## 10.6 Exercises
 
@@ -1338,14 +1338,14 @@ Here is a possible macroexpansion:
 However, often we have a two-field structure that we would like to implement as a cons cell rather than a two-element list, thereby cutting storage in half.
 Since `defstruct` does not allow this, define a new macro that does.
 
-**Exercise 10.3 [m]** Use `reuse-cons` to write a version of `flatten` (see [page 329](B9780080571157500108.xhtml#p329)) that shares as much of its input with its output as possible.
+**Exercise 10.3 [m]** Use `reuse-cons` to write a version of `flatten` (see [page 329](chapter10.md#p329)) that shares as much of its input with its output as possible.
 
 **Exercise 10.4 [h]** Consider the data type *set*.
 A set has two main operations: adjoin an element and test for membership.
 It is convenient to also add a map-over-elements operation.
 With these primitive operations it is possible to build up more complex operations like union and intersection.
 
-As mentioned in [section 3.9](B9780080571157500030.xhtml#s0095), Common Lisp provides several implementations of sets.
+As mentioned in [section 3.9](chapter3.md#s0095), Common Lisp provides several implementations of sets.
 The simplest uses lists as the underlying representation, and provides the functions `adjoin, member, union, intersection`, and `set-difference`.
 Another uses bit vectors, and a similar one uses integers viewed as bit sequences.
 Analyze the time complexity of each implementation for each operation.

--- a/docs/chapter11.md
+++ b/docs/chapter11.md
@@ -9,7 +9,7 @@ Lisp is the major language for AI work, but it is by no means the only one.
 The other strong contender is Prolog, whose name derives from "programming in logic."<a id="tfn11-1"></a><sup>[1](#fn11-1)</sup>
 The idea behind logic programming is that the programmer should state the relationships that describe a problem and its solution.
 These relationships act as constraints on the algorithms that can solve the problem, but the system itself, rather than the programmer, is responsible for the details of the algorithm.
-The tension between the "programming" and "logic" will be covered in [chapter 14](B9780080571157500145.xhtml), but for now it is safe to say that Prolog is an approximation to the ideal goal of logic programming.
+The tension between the "programming" and "logic" will be covered in [chapter 14](chapter14.md), but for now it is safe to say that Prolog is an approximation to the ideal goal of logic programming.
 Prolog has arrived at a comfortable niche between a traditional programming language and a logical specification language.
 It relies on three important ideas:
 
@@ -97,7 +97,9 @@ It is called a *backward-chaining* interpretation, because one reasons backward 
 The symbol <- is appropriate for both interpretations: it is an arrow indicating logical implication, and it points backwards to indicate backward chaining.
 
 It is possible to give more than one procedural interpretation to a declarative form.
-(We did that in [chapter 1](B9780080571157500017.xhtml), where grammar rules were used to generate both strings of words and parse trees.) The rule above could have been interpreted procedurally as "If you ever find out that some `x` likes cats, then conclude that Sandy likes `x`." This would be *forward chaining:* reasoning from a premise to a conclusion.
+(We did that in [chapter 1](chapter1.md), where grammar rules were used to generate both strings of words and parse trees.)
+The rule above could have been interpreted procedurally as "If you ever find out that some `x` likes cats, then conclude that Sandy likes `x`."
+This would be *forward chaining:* reasoning from a premise to a conclusion.
 It turns out that Prolog does backward chaining exclusively.
 Many expert systems use forward chaining exclusively, and some systems use a mixture of the two.
 
@@ -167,7 +169,7 @@ The following example makes it clear that unification treats the symbol + only a
 > (unifier '(?a + ?a = 2) '(?x + ?y = ?y)) => (2 + 2 = 2)
 ```
 
-Before developing the code for `unify`, we repeat here the code taken from the pattern-matching utility ([chapter 6](B9780080571157500066.xhtml)):
+Before developing the code for `unify`, we repeat here the code taken from the pattern-matching utility ([chapter 6](chapter6.md)):
 
 ```lisp
 (defconstant fail nil "Indicates pat-match failure")
@@ -303,7 +305,7 @@ Now let's try a new problem:
 Here `((?X F ?X))` really means `((?X . ((F ?X))))`, so `?X` is bound to (`F ?X`).
 This represents a circular, infinite unification.
 Some versions of Prolog, notably Prolog II ([Giannesini et al.
-1986](B9780080571157500285.xhtml#bb0460)), provide an interpretation for such structures, but it is tricky to define the semantics of infinite structures.
+1986](bibliography.md#bb0460)), provide an interpretation for such structures, but it is tricky to define the semantics of infinite structures.
 
 The easiest way to deal with such infinite structures is just to ban them.
 This ban can be realized by modifying the unifier so that it fails whenever there is an attempt to unify a variable with a structure containing that variable.
@@ -798,11 +800,11 @@ In this section we implement an incremental Prolog interpreter.
 One approach would be to modify the interpreter of the last section to use pipes rather than lists.
 With pipes, unnecessary computation is delayed, and even infinite lists can be expressed in a finite amount of time and space.
 We could change to pipes simply by changing the `mapcan` in `prove` and `prove-all` to `mappend-pipe` (page 286).
-The books by [Winston and Horn (1988)](B9780080571157500285.xhtml#bb1410) and by [Abelson and Sussman (1985)](B9780080571157500285.xhtml#bb0010) take this approach.
+The books by [Winston and Horn (1988)](bibliography.md#bb1410) and by [Abelson and Sussman (1985)](bibliography.md#bb0010) take this approach.
 We take a different one.
 
 The first step is a version of `prove` and `prove-all` that return a single solution rather than a list of all possible solutions.
-This should be reminiscent of `achieve` and `achieve-all` from `gps` ([chapter 4](B9780080571157500042.xhtml)).
+This should be reminiscent of `achieve` and `achieve-all` from `gps` ([chapter 4](chapter4.md)).
 Unlike `gps`, recursive subgoals and clobbered sibling goals are not checked for.
 However, `prove` is required to search systematically through all solutions, so it is passed an additional parameter: a list of other goals to achieve after achieving the first goal.
 This is equivalent to passing a continuation to `prove`.
@@ -1014,7 +1016,7 @@ This means changing the calling function(s) to provide the additional informatio
 * Return a list.
 This means that the calling function(s) must be changed to expect a list of replies.
 
-* Return a *pipe,* as defined in [section 9.3](B9780080571157500091.xhtml#s0020).
+* Return a *pipe,* as defined in [section 9.3](chapter9.md#s0020).
 Again, the calling function(s) must be changed to expect a pipe.
 
 * Guess and save.
@@ -1028,7 +1030,7 @@ Unfortunately, it does have one major difficulty: there has to be a way of packa
 For our Prolog interpreter, the current state is succinctly represented as a list of goals.
 In other problems, it is not so easy to summarize the entire state.
 
-We will see in [section 22.4](B9780080571157500224.xhtml#s0025) that the Scheme dialect of Lisp provides a function, `call-with-current-continuation`, that does exactly what we want: it packages the current state of the computation into a function, which can be stored away and invoked later.
+We will see in [section 22.4](chapter22.md#s0025) that the Scheme dialect of Lisp provides a function, `call-with-current-continuation`, that does exactly what we want: it packages the current state of the computation into a function, which can be stored away and invoked later.
 Unfortunately, there is no corresponding function in Common Lisp.
 
 ### Anonymous Variables
@@ -1064,7 +1066,7 @@ It is installed in the top-level macros `<-` and `?-` so that all clauses and qu
 ```
 
 A named variable that is used only once in a clause can also be considered an anonymous variable.
-This is addressed in a different way in [section 12.3](B9780080571157500121.xhtml#s0020).
+This is addressed in a different way in [section 12.3](chapter12.md#s0020).
 
 ## 11.4 The Zebra Puzzle
 
@@ -1429,24 +1431,24 @@ The programmer must be aware of Prolog's search strategy, using it to implement 
 Prolog, like Lisp, has suffered unfairly from some common myths.
 It has been thought to be an inefficient language because early implementations were interpreted, and because it has been used to write interpreters.
 But modern compiled Prolog can be quite efficient (see [Warren et al.
-1977](B9780080571157500285.xhtml#bb1335) and Van Roy 1990).
+1977](bibliography.md#bb1335) and Van Roy 1990).
 There is a temptation to see Prolog as a solution in itself rather than as a programming language.
 Those who take that view object that Prolog's depth-first search strategy and basis in predicate calculus is too inflexible.
 This objection is countered by Prolog programmers who use the facilities provided by the language to build more powerful search strategies and representations, just as one would do in Lisp or any other language.
 
 ## 11.9 History and References
 
-Cordell [Green (1968)](B9780080571157500285.xhtml#bb0490) was the first to articulate the view that mathematical results on theorem proving could be used to make deductions and thereby answer queries.
-However, the major technique in use at the time, resolution theorem proving (see [Robinson 1965](B9780080571157500285.xhtml#bb0995)), did not adequately constrain search, and thus was not practical.
+Cordell [Green (1968)](bibliography.md#bb0490) was the first to articulate the view that mathematical results on theorem proving could be used to make deductions and thereby answer queries.
+However, the major technique in use at the time, resolution theorem proving (see [Robinson 1965](bibliography.md#bb0995)), did not adequately constrain search, and thus was not practical.
 The idea of goal-directed computing was developed in Carl Hewitt's work (1971) on the PLANNER language for robot problem solving.
 He suggested that the user provide explicit hints on how to control deduction.
 
 At about the same time and independently, Alain Colmerauer was developing a system to perform natural language analysis.
 His approach was to weaken the logical language so that computationally complex statements (such as logical disjunctions) could not be made.
-Colmerauer and his group implemented the first Prolog interpreter using Algol-W in the summer of 1972 (see [Roussel 1975](B9780080571157500285.xhtml#bb1005)).
+Colmerauer and his group implemented the first Prolog interpreter using Algol-W in the summer of 1972 (see [Roussel 1975](bibliography.md#bb1005)).
 It was Roussel's wife, Jacqueline, who came up with the name Prolog as an abbreviation for "programmation en logique." The first large Prolog program was their natural language system, also completed that year ([Colmerauer et al.
-1973](B9780080571157500285.xhtml#bb0255)).
-For those who read English better than French, [Colmerauer (1985)](B9780080571157500285.xhtml#bb0245) presents an overview of Prolog.
+1973](bibliography.md#bb0255)).
+For those who read English better than French, [Colmerauer (1985)](bibliography.md#bb0245) presents an overview of Prolog.
 Robert Kowalski is generally considered the co-inventor of Prolog.
 His 1974 article outlines his approach, and his 1988 article is a historical review on the early logic programming work.
 
@@ -1475,10 +1477,10 @@ Both are experts on Prolog.)
 
 Lloyd's *Foundations of Logic Programming* (1987) provides a theoretical explanation of the formal semantics of Prolog and related languages.
 [Lassez et al.
-(1988)](B9780080571157500285.xhtml#bb0705) and [Knight (1989)](B9780080571157500285.xhtml#bb0625) provide overviews of unification.
+(1988)](bibliography.md#bb0705) and [Knight (1989)](bibliography.md#bb0625) provide overviews of unification.
 
 There have been many attempts to extend Prolog to be closer to the ideal of Logic Programming.
-The language MU-Prolog and NU-Prolog ([Naish 1986](B9780080571157500285.xhtml#bb0890)) and Prolog III ([Colmerauer 1990](B9780080571157500285.xhtml#bb0250)) are particularly interesting.
+The language MU-Prolog and NU-Prolog ([Naish 1986](bibliography.md#bb0890)) and Prolog III ([Colmerauer 1990](bibliography.md#bb0250)) are particularly interesting.
 The latter includes a systematic treatment of the &ne; relation and an interpretation of infinite trees.
 
 ## 11.10 Exercises
@@ -1486,8 +1488,8 @@ The latter includes a systematic treatment of the &ne; relation and an interpret
 **Exercise  11.4 [m]** It is somewhat confusing to see "no" printed after one or more valid answers have appeared.
 Modify the program to print "no" only when there are no answers at all, and "no more" in other cases.
 
-**Exercise  11.5 [h]** At least six books (Abelson and Sussman 1985, [Charniak and McDermott 1985](B9780080571157500285.xhtml#bb0175), Charniak et al.
-1986, [Hennessey 1989](B9780080571157500285.xhtml#bb0530), [Wilensky 1986](B9780080571157500285.xhtml#bb1390), and [Winston and Horn 1988](B9780080571157500285.xhtml#bb1410)) present unification algorithms with a common error.
+**Exercise  11.5 [h]** At least six books (Abelson and Sussman 1985, [Charniak and McDermott 1985](bibliography.md#bb0175), Charniak et al.
+1986, [Hennessey 1989](bibliography.md#bb0530), [Wilensky 1986](bibliography.md#bb1390), and [Winston and Horn 1988](bibliography.md#bb1410)) present unification algorithms with a common error.
 They all have problems unifying (`?x ?y a`) with (`?y ?x ?x`).
 Some of these texts assume that `unify` will be called in a context where no variables are shared between the two arguments.
 However, they are still suspect to the bug, as the following example points out:
@@ -1507,7 +1509,7 @@ Start by making a clear statement of the specification.
 Apply that to the other algorithms, and show where they go wrong.
 Then see if you can prove that the `unify` function in this chapter is correct.
 Failing a complete proof, can you at least prove that the algorithm will always terminate?
-See [Norvig 1991](B9780080571157500285.xhtml#bb0915) for more on this problem.
+See [Norvig 1991](bibliography.md#bb0915) for more on this problem.
 
 **Exercise  11.6 [h]** Since logic variables are so basic to Prolog, we would like them to be efficient.
 In most implementations, structures are not the best choice for small objects.
@@ -1554,7 +1556,7 @@ For example, here's a definition of grandfather that says that G is the grandfat
         (parent ?p ?c))
 ```
 
-**Exercise 11.10 [m]** The following problem is presented in [Wirth 1976](B9780080571157500285.xhtml#bb1415):
+**Exercise 11.10 [m]** The following problem is presented in [Wirth 1976](bibliography.md#bb1415):
 
 *I married a widow (let's call her W) who has a grown-up daughter (call her D).
 My father (F), who visited us often, fell in love with my step-daughter and married her.
@@ -1573,7 +1575,7 @@ Represent this situation using the predicates defined in the previous exercise, 
 
 It is possible to produce 4 instead of `(1+ (1+ (1+ (1+ 0))))` by extending the notion of unification.
 [A&iuml;t-Kaci et al.
-1987](B9780080571157500285.xhtml#bb0025) might give you some ideas how to do this.
+1987](bibliography.md#bb0025) might give you some ideas how to do this.
 
 **Exercise  11.12 [h]** The function `rename-variables` was necessary to avoid confusion between the variables in the first argument to `unify` and those in the second argument.
 An alternative is to change the `unify` so that it takes two binding lists, one for each argument, and keeps them separate.
@@ -1658,4 +1660,4 @@ In this chapter we have adopted the traditional Prolog definition of `member`.
 See exercise 11.12 for an alternative approach.
 
 <a id="fn11-4"></a><sup>[4](#tfn11-4)</sup>
-See the MU-Prolog and NU-Prolog languages ([Naish 1986](B9780080571157500285.xhtml#bb0890)).
+See the MU-Prolog and NU-Prolog languages ([Naish 1986](bibliography.md#bb0890)).

--- a/docs/chapter12.md
+++ b/docs/chapter12.md
@@ -1,9 +1,9 @@
 # Chapter 12
 ## Compiling Logic Programs
 
-The end of [chapter 11](B978008057115750011X.xhtml) introduced a new, more efficient representation for logic variables.
+The end of [chapter 11](chapter11.md) introduced a new, more efficient representation for logic variables.
 It would be reasonable to build a new version of the Prolog interpreter incorporating this representation.
-However, [chapter 9](B9780080571157500091.xhtml) has taught us that compilers run faster than interpreters and are not that much harder to build.
+However, [chapter 9](chapter9.md) has taught us that compilers run faster than interpreters and are not that much harder to build.
 Thus, this chapter will present a Prolog compiler that translates from Prolog to Lisp.
 
 Each Prolog predicate will be translated into a Lisp function, and we will adopt the convention that a predicate called with a different number of arguments is a different predicate.
@@ -614,7 +614,7 @@ Thus, the initial binding list will be:
 ((?arg1 .?arg1) (?arg2 . ?arg2))
 ```
 
-We saw in the previous chapter ([page 354](B978008057115750011X.xhtml#p354)) that binding a variable to itself can lead to problems; we will have to be careful.
+We saw in the previous chapter ([page 354](chapter11.md#p354)) that binding a variable to itself can lead to problems; we will have to be careful.
 
 Besides eliminating unifications of new variables against parameters, there are quite a few other improvements that can be made.
 For example, unifications involving only constants can be done at compile time.
@@ -890,7 +890,7 @@ This change should speed execution time and limit the amount of garbage generate
 Of course, it makes the generated code longer, so that could slow things down if the program ends up spending too much time bringing the code to the processor.
 
 **Exercise  12.1 [h]** Write definitions for `consp-or-variable-p, unify-first!,` and `unify-rest!`, and change the compiler to generate code like that outlined previously.
-You might want to look at the function `compile-rule` in [section 9.6](B9780080571157500091.xhtml#s0035), starting on [page 300](B9780080571157500091.xhtml#p300).
+You might want to look at the function `compile-rule` in [section 9.6](chapter9.md#s0035), starting on [page 300](chapter9.md#p300).
 This function compiled a call to `pat-match` into individual tests; now we want to do the same thing to `unify!`.
 Run some benchmarks to compare the altered compiler to the original version.
 
@@ -1224,7 +1224,7 @@ We can also define `not,` or at least the normal Prolog `not,` which is quite di
 In fact, in some dialects, `not` is written `\+`, which is supposed to be &#x22AC;, that is, "can not be derived."
 The interpretation is that if goal G can not be proved, then (`not G` ) is true.
 Logically, there is a difference between (`not G` ) being true and being unknown, but ignoring that difference makes Prolog a more practical programming language.
-See [Lloyd 1987](B9780080571157500285.xhtml#bb0745) for more on the formal semantics of negation in Prolog.
+See [Lloyd 1987](bibliography.md#bb0745) for more on the formal semantics of negation in Prolog.
 
 Here's an implementation of `not/1`.
 Since it has to manipulate the trail, and we may have other predicates that will want to do the same, we'll package up what was done in `maybe-add-undo-bindings` into the macro `with-undo-bindings:`
@@ -1388,7 +1388,7 @@ Needless to say, `lisp` is not a part of standard Prolog.
  (funcall cont)))
 ```
 
-**Exercise  12.7 [m]** Define the primitive `solve/1`, which works like the function `solve` used in student ([page 225](B9780080571157500078.xhtml#p225)).
+**Exercise  12.7 [m]** Define the primitive `solve/1`, which works like the function `solve` used in student ([page 225](chapter7.md#p225)).
 Decide if it should take a single equation as argument or a list of equations.
 
 **Exercise  12.8 [h]** Assume we had a goal of the form `(solve (=  12 (* (+ ?x 1) 4)))`.
@@ -1587,7 +1587,7 @@ But here there is no way to tell that four of the six goals in the body comprise
 Second, it violates the principle of abstraction.
 A predicate should be understandable as a separate unit.
 But here the predicate process can only be understood by considering the context in which it is called: a context that requires it to fail after processing each command.
-As [Richard O'Keefe 1990](B9780080571157500285.xhtml#bb0925) points out, the correct way to write this clause is as follows:
+As [Richard O'Keefe 1990](bibliography.md#bb0925) points out, the correct way to write this clause is as follows:
 
 ```lisp
 (<- (main)
@@ -1664,13 +1664,13 @@ The Prolog term `p(a,b)` corresponds to the Lisp vector `#(p/2 a b)`, not the li
 A minority of Prolog implementations use *structure sharing.* In this approach, every non-atomic term is represented by a skeleton that contains place holders for variables and a header that points to the skeleton and also contains the variables that will fill the place holders.
 With structure sharing, making a copy is easy: just copy the header, regardless of the size of the skeleton.
 However, manipulating terms is complicated by the need to keep track of both skeleton and header.
-See [Boyer and Moore 1972](B9780080571157500285.xhtml#bb0110) for more on structure sharing.
+See [Boyer and Moore 1972](bibliography.md#bb0110) for more on structure sharing.
 
 Another major difference is that real Prolog uses the equivalent of failure continuations, not success continuations.
 No actual continuation, in the sense of a closure, is built.
 Instead, when a choice is made, the address of the code for the next choice is pushed on a stack.
 Upon failure, the next choice is popped off the stack.
-This is reminiscent of the backtracking approach using Scheme's `call/cc` facility outlined on [page 772](B9780080571157500224.xhtml#p772).
+This is reminiscent of the backtracking approach using Scheme's `call/cc` facility outlined on [page 772](chapter22.md#p772).
 
 **Exercise  12.15 [m]** Assuming an approach using a stack of failure continuations instead of success continuations, show what the code for `p` and `member` would look like.
 Note that you need not pass failure continuations around; you can just push them onto a stack that `top-level-prove` will invoke.
@@ -1679,13 +1679,13 @@ Did we make the right choice in implementing our compiler with success continuat
 
 ## 12.11 History and References
 
-As described in [chapter 11](B978008057115750011X.xhtml), the idea of logic programming was fairly well understood by the mid-1970s.
+As described in [chapter 11](chapter11.md), the idea of logic programming was fairly well understood by the mid-1970s.
 But because the implementations of that time were slow, logic programming did not catch on.
 It was the Prolog compiler for the DEC-10 that made logic programming a serious alternative to Lisp and other general-purpose languages.
 The compiler was developed in 1977 by David H.
 D.
 Warren with Fernando Pereira and Luis Pereira.
-See the paper by [Warren (1979)](B9780080571157500285.xhtml#bb1325) and by all three (1977).
+See the paper by [Warren (1979)](bibliography.md#bb1325) and by all three (1977).
 
 Unfortunately, David H.
 D.
@@ -1693,10 +1693,10 @@ Warren's pioneering work on compiling Prolog has never been published in a widel
 His main contribution was the description of the Warren Abstract Machine (WAM), an instruction set for compiled Prolog.
 Most existing compilers use this instruction set, or a slight modification of it.
 This can be done either through byte-code interpretation or through macroexpansion to native machine instructions.
-[A&iuml;t-Kaci 1991](B9780080571157500285.xhtml#bb0020) provides a good tutorial on the WAM, much less terse than the original ([Warren 1983](B9780080571157500285.xhtml#bb1330)).
+[A&iuml;t-Kaci 1991](bibliography.md#bb0020) provides a good tutorial on the WAM, much less terse than the original ([Warren 1983](bibliography.md#bb1330)).
 The compiler presented in this chapter does not use the WAM.
-Instead, it is modeled after Mark [Stickel's (1988)](B9780080571157500285.xhtml#bb1200) theorem prover.
-A similar compiler is briefly sketched by Jacques [Cohen 1985](B9780080571157500285.xhtml#bb0225).
+Instead, it is modeled after Mark [Stickel's (1988)](bibliography.md#bb1200) theorem prover.
+A similar compiler is briefly sketched by Jacques [Cohen 1985](bibliography.md#bb0225).
 
 ## 12.12 Exercises
 

--- a/docs/chapter13.md
+++ b/docs/chapter13.md
@@ -42,7 +42,7 @@ Examples of object-oriented languages are Simula, C++, and CLOS, the Common Lisp
 This chapter will first introduce object-oriented programming in general, and then concentrate on the Common Lisp Object System.
 
 Many people are promoting object-oriented programming as the solution to the software development problem, but it is hard to get people to agree on just what object-orientation means.
-[Peter Wegner 1987](B9780080571157500285.xhtml#bb1355) proposes the following formula as a definition:
+[Peter Wegner 1987](bibliography.md#bb1355) proposes the following formula as a definition:
 
 *Object-orientation = Objects + Classes + Inheritance*
 
@@ -570,7 +570,7 @@ But once the writer function is defined it can be used anywhere, so an unscrupul
 ## 13.8 A CLOS Example: Searching Tools
 
 CLOS is most appropriate whenever there are several types that share related behavior.
-A good example of an application that fits this description is the set of searching tools defined in [section 6.4](B9780080571157500066.xhtml#s0025).
+A good example of an application that fits this description is the set of searching tools defined in [section 6.4](chapter6.md#s0025).
 There we defined functions for breadth-first, depth-first, and best-first search, as well as tree- and graph-based search.
 We also defined functions to search in particular domains, such as planning a route between cities.
 
@@ -589,7 +589,7 @@ The basic class, `problem`, contains a single-instance variable to hold the unex
  ((states :initarg :states :accessor problem-states)))
 ```
 
-The function searcher is similar to the function `tree-search` of [section 6.4](B9780080571157500066.xhtml#s0025).
+The function searcher is similar to the function `tree-search` of [section 6.4](chapter6.md#s0025).
 The main difference is that searcher uses generic functions instead of passing around functional arguments.
 
 ```lisp
@@ -666,7 +666,7 @@ But Lisp provides such nice list-manipulation primitives that it is difficult to
 Of course, the user who defines a new implementation for `problem-states` could just redefine `problem-combiner` for the offending classes, but this is precisely what object-oriented programming is designed to avoid: specializing one abstraction (states) should not force us to change anything in another abstraction (search strategy).
 
 The last step is to define a class that represents a particular domain, and define `problem-successors` for that domain.
-As the first example, consider the simple binary tree search from [section 6.4](B9780080571157500066.xhtml#s0025).
+As the first example, consider the simple binary tree search from [section 6.4](chapter6.md#s0025).
 Naturally, this gets represented as a class:
 
 ```lisp
@@ -761,7 +761,7 @@ As usual, we have to make up another class to represent this type of problem:
 ```
 
 So far the case for CLOS has not been compelling.
-The code in this section duplicates the functionality of code in [section 6.4](B9780080571157500066.xhtml#s0025), but the CLOS code tends to be more verbose, and it is somewhat disturbing that we had to make up so many long class names.
+The code in this section duplicates the functionality of code in [section 6.4](chapter6.md#s0025), but the CLOS code tends to be more verbose, and it is somewhat disturbing that we had to make up so many long class names.
 However, this verbosity leads to flexibility, and it is easier to extend the CLOS code by adding new specialized classes.
 It is useful to make a distinction between the systems programmer and the applications programmer.
 The systems programmer would supply a library of classes like `dfs-problem` and generic functions like `searcher`.
@@ -909,7 +909,7 @@ Thus, an object-oriented program will probably be compatible with other programs
 
 ## 13.11 History and References
 
-The first object-oriented language was Simula, which was designed by Ole-Johan Dahl and Krysten Nygaard ([1966](B9780080571157500285.xhtml#bb0265), [Nygaard and Dahl 1981](B9780080571157500285.xhtml#bb0920)) as an extension of Algol 60.
+The first object-oriented language was Simula, which was designed by Ole-Johan Dahl and Krysten Nygaard ([1966](bibliography.md#bb0265), [Nygaard and Dahl 1981](bibliography.md#bb0920)) as an extension of Algol 60.
 It is still in use today, mostly in Norway and Sweden.
 Simula provides the ability to define classes with single inheritance.
 Methods can be inherited from a superclass or overridden by a subclass.
@@ -918,8 +918,8 @@ Although Simula is a general-purpose language, it provides special support for s
 The built-in class `simulation` allows a programmer to keep track of simulated time while running a set of processes as coroutines.
 
 In 1969 Alan Kay was a graduate student at the University of Utah.
-He became aware of Simula and realized that the object-oriented style was well suited to his research in graphics ([Kay 1969](B9780080571157500285.xhtml#bb0600)).
-A few years later, at Xerox, he joined with Adele Goldberg and Daniel Ingalls to develop the Smalltalk language (see [Goldberg and Robinson 1983](B9780080571157500285.xhtml#bb0475)).
+He became aware of Simula and realized that the object-oriented style was well suited to his research in graphics ([Kay 1969](bibliography.md#bb0600)).
+A few years later, at Xerox, he joined with Adele Goldberg and Daniel Ingalls to develop the Smalltalk language (see [Goldberg and Robinson 1983](bibliography.md#bb0475)).
 While Simula can be viewed as an attempt to add object-oriented features to strongly typed Algol 60, Smalltalk can be seen as an attempt to use the dynamic, loosely typed features of Lisp, but with methods and objects replacing functions and s-expressions.
 In Simula, objects existed alongside traditional data types like numbers and strings; in Smalltalk, every datum is an object.
 This gave Smalltalk the feel of an integrated Lisp environment, where the user can inspect, copy, or edit any part of the environment.
@@ -929,8 +929,8 @@ Guy Steele's *LAMBDA: The Ultimate Declarative* (1976a and b) was perhaps the fi
 As the title suggests, it was all done using `lambda,` in a similar way to our `define-class` example.
 Steele summarized the approach with the equation "Actors = Closures (mod Syntax)," refering to Carl Hewitt's "Actors" object-oriented formalism.
 
-In 1979, the MIT Lisp Machine group developed the Flavors system based on this approach but offering considerable extensions ([Cannon 1980](B9780080571157500285.xhtml#bb0155), [Weinreb 1980](B9780080571157500285.xhtml#bb1360), [Moon et al.
-1983](B9780080571157500285.xhtml#bb0860)).
+In 1979, the MIT Lisp Machine group developed the Flavors system based on this approach but offering considerable extensions ([Cannon 1980](bibliography.md#bb0155), [Weinreb 1980](bibliography.md#bb1360), [Moon et al.
+1983](bibliography.md#bb0860)).
 "Flavor" was a popular jargon word for "type" or "kind" at MIT, so it was natural that it became the term for what we call classes.
 
 The Flavor system was the first to support multiple inheritance.
@@ -967,27 +967,27 @@ This system was known as New Flavors.
 It had a strong influence on the eventual CLOS design.
 
 The other strong influence on CLOS was the CommonLoops system developed at Xerox PARC.
-(See [Bobrow 1982](B9780080571157500285.xhtml#bb0095), [Bobrow et al.
-1986](B9780080571157500285.xhtml#bb0105), [Stefik and Bobrow 1986](B9780080571157500285.xhtml#bb1185).) CommonLoops continued the New Flavors trend away from message passing by introducing *multimethods*: methods that specialize on more than one argument.
+(See [Bobrow 1982](bibliography.md#bb0095), [Bobrow et al.
+1986](bibliography.md#bb0105), [Stefik and Bobrow 1986](bibliography.md#bb1185).) CommonLoops continued the New Flavors trend away from message passing by introducing *multimethods*: methods that specialize on more than one argument.
 
 As of summer 1991, CLOS itself is in a state of limbo.
 It was legitimized by its appearance in *Common Lisp the Language*, 2d edition, but it is not yet official, and an important part, the metaobject protocol, is not yet complete.
-A tutorial on CLOS is [Keene 1989](B9780080571157500285.xhtml#bb0620).
+A tutorial on CLOS is [Keene 1989](bibliography.md#bb0620).
 
 We have seen how easy it is to build an object-oriented system on top of Lisp, using `lambda` as the primary tool.
 An interesting alternative is to build Lisp on top of an object-oriented system.
-That is the approach taken in the Oaklisp system of [Lang and Perlmutter (1988)](B9780080571157500285.xhtml#bb0695).
+That is the approach taken in the Oaklisp system of [Lang and Perlmutter (1988)](bibliography.md#bb0695).
 Instead of defining methods using `lambda` as the primitive, Oaklisp has `add-method` as a primitive and defines `lambda` as a macro that adds a method to an anonymous, empty operation.
 
 Of course, object-oriented systems are thriving outside the Lisp world.
 With the success of UNIX-based workstations, C has become one of the most widely available programming languages.
 C is a fairly low-level language, so there have been several attempts to use it as a kind of portable assembly language.
-The most successful of these attempts is C++, a language developed by Bjarne Stroustrup of AT&T Bell Labs ([Stroustrup 1986](B9780080571157500285.xhtml#bb1210)).
+The most successful of these attempts is C++, a language developed by Bjarne Stroustrup of AT&T Bell Labs ([Stroustrup 1986](bibliography.md#bb1210)).
 C++ provides a number of extensions, including the ability to define classes.
 However, as an add-on to an existing language, it does not provide as many features as the other languages discussed here.
 Crucially, it does not provide garbage collection, nor does it support fully generic functions.
 
-Eiffel ([Meyer 1988](B9780080571157500285.xhtml#bb0830)) is an attempt to define an object-oriented system from the ground up rather than tacking it on to an existing language.
+Eiffel ([Meyer 1988](bibliography.md#bb0830)) is an attempt to define an object-oriented system from the ground up rather than tacking it on to an existing language.
 Eiffel supports multiple inheritance and garbage collection and a limited amount of dynamic dispatching.
 
 So-called modern languages like Ada and Modula support information-hiding through generic functions and classes, but they do not provide inheritance, and thus can not be classified as true object-oriented languages.

--- a/docs/chapter14.md
+++ b/docs/chapter14.md
@@ -23,7 +23,7 @@ The general inferencing mechanisms that worked on toy examples just did not scal
 
 The *expert-system* approach offered an alternative.
 The key to solving hard problems was seen to be the acquisition of special-case rules to break the problem into easier problems.
-According to Feigenbaum, the lesson learned from expert systems like MYCIN (which we will see in [chapter 16](B9780080571157500169.xhtml)) is that the choice of inferencing mechanism is not as important as having the right knowledge.
+According to Feigenbaum, the lesson learned from expert systems like MYCIN (which we will see in [chapter 16](chapter16.md)) is that the choice of inferencing mechanism is not as important as having the right knowledge.
 In this view it doesn't matter very much if MYCIN uses forward- or backward-chaining, or if it uses certainty factors, probabilities, or fuzzy set theory.
 What matters crucially is that we know pseudomonas is a gram-negative, rod-shaped organism that can infect patients with compromised immune systems.
 In other words, the key problem is acquiring and representing knowledge.
@@ -218,7 +218,7 @@ Introducing negation wrecks havoc on the simple Prolog evaluation scheme.
 It is no longer sufficient to consider a single clause at a time.
 Rather, multiple clauses must be considered together if we want to derive all the right answers.
 
-Robert [Moore 1982](B9780080571157500285.xhtml#bb0865) gives a good example of the power of disjunctive reasoning.
+Robert [Moore 1982](bibliography.md#bb0865) gives a good example of the power of disjunctive reasoning.
 His problem concerned three colored blocks, but we will update it to deal with three countries.
 Suppose that a certain Eastern European country, *E*, has just decided if it will remain under communist rule or become a democracy, but we do not know the outcome of the decision.
 *E* is situated between the democracy *D* and the communist country *C*:
@@ -480,7 +480,7 @@ The solutions to the three problems-expressiveness, completeness, and indexing-w
 
 A better solution to the phone-book problem is to index each phone-book entry in some kind of table that makes it easy to add, delete, and retrieve entries.
 That is what we will do in this section.
-We will develop an extension of the trie or discrimination tree data structure built in [section 10.5](B9780080571157500108.xhtml#s0030) ([page 344](B9780080571157500108.xhtml#p344)).
+We will develop an extension of the trie or discrimination tree data structure built in [section 10.5](chapter10.md#s0030) ([page 344](chapter10.md#p344)).
 
 Making a discrimination tree for Prolog facts is complicated by the presence of variables in both the facts and the query.
 Either facts with variables in them will have to be indexed in several places, or queries with variables will have to look in several places, or both.
@@ -649,7 +649,7 @@ Property lists would not work, because they are searched using eq and atoms can 
 Association lists are searched using `eql` by default.
 An alternative would be to use hash tables for the index, or even to use a scheme that starts with association lists and switches to a hash table when the number of entries gets large.
 I use `lookup` to look up the value of a key in a property list.
-This function, and its `setf` method, are defined on [page 896](B978008057115750025X.xhtml#p896).
+This function, and its `setf` method, are defined on [page 896](chapter25.md#p896).
 
 ```lisp
 (defun index (key)
@@ -792,7 +792,7 @@ Now let's stop and see what we have accomplished.
 The functions `fetch and dtree-fetch` fulfill their contract of returning potential matches.
 However, we still need to integrate the dtree facility with Prolog.
 We need to go through the potential matches and determine which candidates are actual matches.
-For simplicity we will use the version of `unify` with binding lists defined in [section 11.2](B978008057115750011X.xhtml#s0020).
+For simplicity we will use the version of `unify` with binding lists defined in [section 11.2](chapter11.md#s0020).
 (It is also possible to construct a more efficient version that uses the compiler and the destructive function `unify!`.)
 
 The function `mapc-retrieve` calls `fetch` to get a list-of-lists of potential matches and then calls `unify` to see if the match is a true one.
@@ -908,7 +908,7 @@ Here is the implementation:
 
 ## 14.9 A Solution to the Completeness Problem
 
-We saw in [chapter 6](B9780080571157500066.xhtml) that iterative deepening is an efficient way to cover a search space without falling into an infinite loop.
+We saw in [chapter 6](chapter6.md) that iterative deepening is an efficient way to cover a search space without falling into an infinite loop.
 Iterative deepening can also be used to guide the search in Prolog.
 It will insure that all valid answers are found eventually, but it won't turn an infinite search space into a finite one.
 
@@ -1794,7 +1794,7 @@ Here we see that the facts entered in `W7031` are not accessible, but the facts 
 
 ### Unification, Equality, Types, and Skolem Constants
 
-The lesson of the zebra puzzle in [section 11.4](B978008057115750011X.xhtml#s0040) was that unification can be used to lessen the need for backtracking, because an uninstantiated logic variable or partially instantiated term can stand for a whole range of possible solutions.
+The lesson of the zebra puzzle in [section 11.4](chapter11.md#s0040) was that unification can be used to lessen the need for backtracking, because an uninstantiated logic variable or partially instantiated term can stand for a whole range of possible solutions.
 However, this advantage can quickly disappear when the representation forces the problem solver to enumerate possible solutions rather than treating a whole range of solutions as one.
 For example, consider the following query in the frame language and its expansion into primitives:
 
@@ -1821,40 +1821,41 @@ The equality mechanism is used to keep track of each Skolem variable's possible 
 
 ## 14.11 History and References
 
-[Brachman and Levesque (1985)](B9780080571157500285.xhtml#bb0115) collect thirty of the key papers in knowledge representation.
-Included are some early approaches to semantic network based ([Quillian 1967](B9780080571157500285.xhtml#bb0965)) and logic-based ([McCarthy 1968](B9780080571157500285.xhtml#bb0805)) representation.
-Two thoughtful critiques of the ad hoc use of representations without defining their meaning are by [Woods (1975)](B9780080571157500285.xhtml#bb1430) and [McDermott (1978)](B9780080571157500285.xhtml#bb0820).
-It is interesting to contrast the latter with [McDermott 1987](B9780080571157500285.xhtml#bb0825), which argues that logic by itself is not sufficient to solve the problems of AI.
+[Brachman and Levesque (1985)](bibliography.md#bb0115) collect thirty of the key papers in knowledge representation.
+Included are some early approaches to semantic network based ([Quillian 1967](bibliography.md#bb0965)) and logic-based ([McCarthy 1968](bibliography.md#bb0805)) representation.
+Two thoughtful critiques of the ad hoc use of representations without defining their meaning are by [Woods (1975)](bibliography.md#bb1430) and [McDermott (1978)](bibliography.md#bb0820).
+It is interesting to contrast the latter with [McDermott 1987](bibliography.md#bb0825), which argues that logic by itself is not sufficient to solve the problems of AI.
 This argument should not be surprising to those who remember the slogan *logic = algorithm - control.*
 
-[Genesereth and Nilsson's textbook (1987)](B9780080571157500285.xhtml#bb0455) cover the predicate-calculus-based approach to knowledge representation and AI in general.
-[Ernest Davis (1990)](B9780080571157500285.xhtml#bb0275) presents a good overview of the field that includes specialized representations for time, space, qualitative physics, propositional attitudes, and the interaction between agents.
+[Genesereth and Nilsson's textbook (1987)](bibliography.md#bb0455) cover the predicate-calculus-based approach to knowledge representation and AI in general.
+[Ernest Davis (1990)](bibliography.md#bb0275) presents a good overview of the field that includes specialized representations for time, space, qualitative physics, propositional attitudes, and the interaction between agents.
 
 Many representation languages focus on the problem of defining descriptions for categories of objects.
-These have come to be known as *term-subsumption languages.* Examples include KL-ONE ([Schmolze and Lipkis 1983](B9780080571157500285.xhtml#bb1060)) and KRYPTON ([Brachman, Fikes, and Levesque 1983](B9780080571157500285.xhtml#bb0120)).
-See [Lakoff 1987](B9780080571157500285.xhtml#bb0685) for much more on the problem of categories and prototypes.
+These have come to be known as *term-subsumption languages.*
+Examples include KL-ONE ([Schmolze and Lipkis 1983](bibliography.md#bb1060)) and KRYPTON ([Brachman, Fikes, and Levesque 1983](bibliography.md#bb0120)).
+See [Lakoff 1987](bibliography.md#bb0685) for much more on the problem of categories and prototypes.
 
-Hector [Levesque (1986)](B9780080571157500285.xhtml#bb0720) points out that the areas Prolog has difficulty with-disjunction, negation, and existentials-all involve a degree of vagueness.
+Hector [Levesque (1986)](bibliography.md#bb0720) points out that the areas Prolog has difficulty with-disjunction, negation, and existentials-all involve a degree of vagueness.
 In his term, they lack *vividness.* A vivid proposition is one that could be represented directly in a picture: the car is blue; she has a martini in her left hand; Albany is the capital of New York.
 Nonvivid propositions cannot be so represented: the car is not blue; she has a martini in one hand; either Albany or New York City is the capital of New York.
 There is interest in separating vivid from nonvivid reasoning, but no current systems are actually built this way.
 
-The possible world approach of [section 14.10](#s0055) was used in the MRS system ([Russell 1985](B9780080571157500285.xhtml#bb1020)).
+The possible world approach of [section 14.10](#s0055) was used in the MRS system ([Russell 1985](bibliography.md#bb1020)).
 More recent knowledge representation systems tend to use truth maintenance systems instead of possible worlds.
-This approach was pioneered by [Doyle (1979)](B9780080571157500285.xhtml#bb0340) and [McAllester (1982)](B9780080571157500285.xhtml#bb0785).
+This approach was pioneered by [Doyle (1979)](bibliography.md#bb0340) and [McAllester (1982)](bibliography.md#bb0785).
 Doyle tried to change the name to "reason maintenance,' in (1983), but it was too late.
 The version in widest used today is the assumption-based truth maintenance system, or ATMS, developed by de Kleer (1986a,b,c).
 [Charniak et al.
-(1987)](B9780080571157500285.xhtml#bb0180) present a complete Common Lisp implementation of a McAllester-style TMS.
+(1987)](bibliography.md#bb0180) present a complete Common Lisp implementation of a McAllester-style TMS.
 
 There is little communication between the logic programming and knowledge representation communities, even though they cover overlapping territory.
-[Colmerauer (1990)](B9780080571157500285.xhtml#bb0250) and [Cohen (1990)](B9780080571157500285.xhtml#bb0230) describe Logic Programming languages that address some of the issues covered in this chapter.
-Key papers in equality reasoning include Galler and Fisher 1974, [Kornfeld 1983](B9780080571157500285.xhtml#bb0645),<a id="tfn14-1"></a><sup>[1](#fn14-1)</sup>
-Jaffar, Lassez, and Maher 1984, and [van Emden and Yukawa 1987](B9780080571157500285.xhtml#bb1265).
-[H&ouml;lldobler's book (1987)](B9780080571157500285.xhtml#bb0550) includes an overview of the area.
+[Colmerauer (1990)](bibliography.md#bb0250) and [Cohen (1990)](bibliography.md#bb0230) describe Logic Programming languages that address some of the issues covered in this chapter.
+Key papers in equality reasoning include Galler and Fisher 1974, [Kornfeld 1983](bibliography.md#bb0645),<a id="tfn14-1"></a><sup>[1](#fn14-1)</sup>
+Jaffar, Lassez, and Maher 1984, and [van Emden and Yukawa 1987](bibliography.md#bb1265).
+[H&ouml;lldobler's book (1987)](bibliography.md#bb0550) includes an overview of the area.
 Papers on extending unification in ways other than equality include [A&iuml;t-Kaci et al.
-1987](B9780080571157500285.xhtml#bb0025) and [Staples and Robinson 1988](B9780080571157500285.xhtml#bb1125).
-Finally, papers on extending Prolog to cover disjunction and negation (i.e., non-Horn clauses) include [Loveland 1987](B9780080571157500285.xhtml#bb0755), [Plaisted 1988](B9780080571157500285.xhtml#bb0960), and [Stickel 1988](B9780080571157500285.xhtml#bb1200).
+1987](bibliography.md#bb0025) and [Staples and Robinson 1988](bibliography.md#bb1125).
+Finally, papers on extending Prolog to cover disjunction and negation (i.e., non-Horn clauses) include [Loveland 1987](bibliography.md#bb0755), [Plaisted 1988](bibliography.md#bb0960), and [Stickel 1988](bibliography.md#bb1200).
 
 ## 14.12 Exercises
 
@@ -1917,4 +1918,4 @@ Now figure out how to find all the nlists that an item is indexed under.
 ----------------------
 
 <a id="fn14-1"></a><sup>[1](#tfn14-1)</sup>
-A commentary on this paper appears in [Elcock and Hoddinott 1986](B9780080571157500285.xhtml#bb0360).
+A commentary on this paper appears in [Elcock and Hoddinott 1986](bibliography.md#bb0360).

--- a/docs/chapter15.md
+++ b/docs/chapter15.md
@@ -872,7 +872,7 @@ A brief history of symbolic algebra systems is given in [chapter 8](chapter8.md)
 ----------------------
 
 <a id="fn15-1"></a><sup>[1](#tfn15-1)</sup>
-In fact, the algebraic properties of polynomial arithmetic and its generalizations fit so well with ideas in data abstraction that an extended example (in Scheme) on this topic is provided in *Structure and Interpretation of Computer Programs* by Abelson and Sussman (see section 2.4.3, [pages 153](B9780080571157500054.xhtml#p153)-[166](B9780080571157500054.xhtml#p166)).
+In fact, the algebraic properties of polynomial arithmetic and its generalizations fit so well with ideas in data abstraction that an extended example (in Scheme) on this topic is provided in *Structure and Interpretation of Computer Programs* by Abelson and Sussman (see section 2.4.3, pages 153-166).
 We'll pursue a slightly different approach here.
 
 <a id="fn15-2"></a><sup>[2](#tfn15-2)</sup>

--- a/docs/chapter15.md
+++ b/docs/chapter15.md
@@ -5,16 +5,16 @@
 
 > -David Hockney
 
-[Chapter 8](B978008057115750008X.xhtml) started with high hopes: to take an existing pattern matcher, copy down some mathematical identities out of a reference book, and come up with a usable symbolic algebra system.
+[Chapter 8](chapter8.md) started with high hopes: to take an existing pattern matcher, copy down some mathematical identities out of a reference book, and come up with a usable symbolic algebra system.
 The resulting system *was* usable for some purposes, and it showed that the technique of rule-based translation is a powerful one.
-However, the problems of [section 8.5](B978008057115750008X.xhtml#s0030) show that not everything can be done easily and efficiently within the rule-based pattern matching framework.
+However, the problems of [section 8.5](chapter8.md#s0030) show that not everything can be done easily and efficiently within the rule-based pattern matching framework.
 
 There are important mathematical transformations that are difficult to express in the rule-based approach.
 For example, dividing two polynomials to obtain a quotient and remainder is a task that is easier to express as an algorithm-a program-than as a rule or set of rules.
 
 In addition, there is a problem with efficiency.
 Pieces of the input expressions are simplified over and over again, and much time is spent interpreting rules that do not apply.
-[Section 9.6](B9780080571157500091.xhtml#s0035) showed some techniques for speeding up the program by a factor of 100 on inputs of a dozen or so symbols, but for expressions with a hundred or so symbols, the speed-up is not enough.
+[Section 9.6](chapter9.md#s0035) showed some techniques for speeding up the program by a factor of 100 on inputs of a dozen or so symbols, but for expressions with a hundred or so symbols, the speed-up is not enough.
 We can do better by designing a specialized representation from the ground up.
 
 Serious algebraic manipulation programs generally enforce a notion of *canonical simplification.* That is, expressions are converted into a canonical internal format that may be far removed from the input form.
@@ -138,7 +138,7 @@ Figure 15.1: Glossary for the Symbolic Manipulation Program
 
 The functions defining the type `polynomial` follow.
 Because we are concerned with efficiency, we proclaim certain short functions to be compiled inline, use the specific function `svref` (simple-vector reference) rather than the more general aref, and provide declarations for the polynomials using the special form the.
-More details on efficiency issues are given in [Chapter 9](B9780080571157500091.xhtml).
+More details on efficiency issues are given in [Chapter 9](chapter9.md).
 
 ```lisp
 (proclaim '(inline main-var degree coef
@@ -195,7 +195,7 @@ So the `defsetf` for `main-var` says that `(setf (main-varp) val)` is equivalent
 A `defsetf` is much like a `defmacro`, but there is a little less burden placed on the writer of `defsetf`.
 Instead of passing `p` and `val` directly to the `setf` method, Common Lisp binds local variables to these expressions, and passes those variables to the `setf` method.
 That way, the writer does not have to worry about evaluating the expressions in the wrong order or the wrong number of times.
-It is also possible to gain finer control over the whole process with `define-setf-method`, as explained on [page 884](B978008057115750025X.xhtml#p884).
+It is also possible to gain finer control over the whole process with `define-setf-method`, as explained on [page 884](chapter25.md#p884).
 
 The functions `poly+poly, poly*poly` and `poly^n` perform addition, multiplication, and exponentiation of polynomials, respectively.
 They are defined with several helping functions.
@@ -572,7 +572,7 @@ We can time `(simp ' ( (1 + x + y + z) ^ 15)))`.
 This takes only a tenth of a second, but that is because it is doing no work at all-the answer is the same as the input!
 Alternately, we can take the expression computed by `(poly^n r 15)`, convert it to prefix, and pass that to `simplify`.
 `simplify` takes 27.8 seconds on this, so the rule-based version is much slower.
-[Section 9.6](B9780080571157500091.xhtml#s0035) describes ways to speed up the rule-based program, and a comparison of timing data appears on [page 525](#p525).
+[Section 9.6](chapter9.md#s0035) describes ways to speed up the rule-based program, and a comparison of timing data appears on [page 525](#p525).
 
 There are always surprises when it comes down to measuring timing data.
 For example, the alert reader may have noticed that the version of `poly^n` defined above requires *n* multiplications.
@@ -630,7 +630,7 @@ For this problem, it is clear that thinking recursively leads to a simpler funct
 
 It turns out that this is not the final word.
 Exponentiation of polynomials can be done even faster, with a little more mathematical sophistication.
-[Richard Fateman's 1974](B9780080571157500285.xhtml#bb0380) paper on Polynomial Multiplication analyzes the complexity of a variety of exponentiation algorithms.
+[Richard Fateman's 1974](bibliography.md#bb0380) paper on Polynomial Multiplication analyzes the complexity of a variety of exponentiation algorithms.
 Instead of the usual asymptotic analysis (e.g.
 *O*(*n*) or *O*(*n*<sup>2</sup>)), he uses a fine-grained analysis that computes the constant factors (e.g.
 1000 x *n* or 2 x *n*<sup>2</sup>).
@@ -797,7 +797,7 @@ If we are interested in assuring we have a canonical form, the safest thing is t
 All the other functions can be defined in terms of these two.
 With this extension, the set of expressions we can form is closed under differentiation, and it is possible to canonicalize expressions.
 The `result` is a mathematically sound construction known as a *differentiable field.*
-This is precisely the construct that is assumed by the Risch integration algorithm ([Risch 1969](B9780080571157500285.xhtml#bb0985), [1979](B9780080571157500285.xhtml#bb0990)).
+This is precisely the construct that is assumed by the Risch integration algorithm ([Risch 1969](bibliography.md#bb0985), [1979](bibliography.md#bb0990)).
 
 The disadvantage of this minimal extension is that answers may be expressed in unfamiliar terms.
 The user asks for *d* sin(*x*<sup>2</sup>)*/dx,* expecting a simple answer in terms of cos, and is surprised to see a complex answer involving *e<sup>ix</sup>*.
@@ -808,10 +808,10 @@ In general, the result will not be a wrong answer but rather the failure to find
 
 ## 15.7 History and References
 
-A brief history of symbolic algebra systems is given in [chapter 8](B978008057115750008X.xhtml).
-[Fateman (1979)](B9780080571157500285.xhtml#bb0385), [Martin and Fateman (1971)](B9780080571157500285.xhtml#bb0775), and [Davenport et al.
-(1988)](B9780080571157500285.xhtml#bb0270) give more details on the MACSYMA system, on which this chapter is loosely based.
-[Fateman (1991)](B9780080571157500285.xhtml#bb0390) discusses the `frpoly` benchmark and introduces the vector implementation used in this chapter.
+A brief history of symbolic algebra systems is given in [chapter 8](chapter8.md).
+[Fateman (1979)](bibliography.md#bb0385), [Martin and Fateman (1971)](bibliography.md#bb0775), and [Davenport et al.
+(1988)](bibliography.md#bb0270) give more details on the MACSYMA system, on which this chapter is loosely based.
+[Fateman (1991)](bibliography.md#bb0390) discusses the `frpoly` benchmark and introduces the vector implementation used in this chapter.
 
 ## 15.8 Exercises
 
@@ -819,9 +819,9 @@ A brief history of symbolic algebra systems is given in [chapter 8](B97800805711
 
 **Exercise 15.8 [m]** Modify `deriv` to handle the extended rational expressions.
 
-**Exercise 15.9 [d]** Adapt the integration routine from [section 8.6](B9780080571157500078.xhtml#s0035) ([page 252](B978008057115750008X.xhtml#p252)) to the rational expression representation.
+**Exercise 15.9 [d]** Adapt the integration routine from [section 8.6](chapter8.md#s0035) ([page 252](chapter8.md#p252)) to the rational expression representation.
 [Davenport et al.
-1988](B9780080571157500285.xhtml#bb0270) may be useful.
+1988](bibliography.md#bb0270) may be useful.
 
 **Exercise 15.10 [s]** Give several reasons why constant polynomials, like 3, are represented as integers rather than as vectors.
 

--- a/docs/chapter16.md
+++ b/docs/chapter16.md
@@ -1201,7 +1201,7 @@ If there is a problem, fix it.
 
 The remaining exercises discuss extensions that were in the original EMYCIN, but were not implemented in our version.
 Implementing all the extensions will result in a system that is very close to the full power of EMYCIN.
-These extensions are discussed in [chapter 3](B9780080571157500030.xhtml) of [Buchanan and Shortliffe 1984](B9780080571157500285.xhtml#bb0145).
+These extensions are discussed in chapter 3 of [Buchanan and Shortliffe 1984](bibliography.md#bb0145).
 
 **Exercise  16.9 [h]** Add a spelling corrector to `ask-vals`.
 If the user enters an invalid reply, and the parameter type is a `member` expression, check if the reply is "close" in spelling to one of the valid values, and if so, use that value.

--- a/docs/chapter16.md
+++ b/docs/chapter16.md
@@ -769,7 +769,7 @@ It also checks that conclusions use only the operator `is`:
 ```
 
 The real EMYCIN had an interactive environment that prompted the expert for each context, parameter, and rule.
-Randall Davis ([1977](B9780080571157500285.xhtml#bb0290), [1979](B9780080571157500285.xhtml#bb0295), [Davis and Lenat 1982](B9780080571157500285.xhtml#bb0300)) describes the TEIRESIAS program, which helped experts enter and debug rules.
+Randall Davis ([1977](bibliography.md#bb0290), [1979](bibliography.md#bb0295), [Davis and Lenat 1982](bibliography.md#bb0300)) describes the TEIRESIAS program, which helped experts enter and debug rules.
 
 ## 16.7 Interacting with the Client
 
@@ -943,7 +943,7 @@ Each parameter is given a type, and most are given prompts to improve the natura
 ```
 
 Now we need some rules to help determine the identity of the organisms.
-The following rules are taken from [Shortliffe 1976](B9780080571157500285.xhtml#bb1100).
+The following rules are taken from [Shortliffe 1976](bibliography.md#bb1100).
 The rule numbers refer to the pages on which they are listed.
 The real MYCIN had about 400 rules, dealing with a much wider variety of premises and conclusions.
 
@@ -1122,7 +1122,7 @@ Before MYCIN, most reasoning with uncertainty was done using probability theory.
 The laws of probability-in particular, Bayes's law-provide a well-founded mathematical formalism that is not subject to the inconsistencies of certainty factors.
 Indeed, probability theory can be shown to be the only formalism that leads to rational behavior, in the sense that if you have to make a series of bets on some uncertain events, combining information with probability theory will give you the highest expected value for your bets.
 Despite this, probability theory was largely set aside in the mid-1970s.
-The argument made by [Shortliffe and Buchanan (1975)](B9780080571157500285.xhtml#bb1105) was that probability theory required too many conditional probabilities, and that people were not good at estimating these.
+The argument made by [Shortliffe and Buchanan (1975)](bibliography.md#bb1105) was that probability theory required too many conditional probabilities, and that people were not good at estimating these.
 They argued that certainty factors were intuitively easier to deal with.
 Other researchers of the time shared this view.
 Shafer, with later refinements by Dempster, created a theory of belief functions that, like certainty factors, represented a combination of the belief for and against an event.
@@ -1133,7 +1133,7 @@ A great deal of effort in the late 1970s and early 1980s was invested in these a
 Another example is Zadeh's fuzzy set theory, which is also based on intervals.
 
 There is ample evidence that people have difficulty with problems involving probability.
-In a very entertaining and thought-provoking series of articles, Tversky and Kahneman ([1974](B9780080571157500285.xhtml#bb1245), [1983](B9780080571157500285.xhtml#bb1250), [1986](B9780080571157500285.xhtml#bb1255)) show how people make irrational choices when faced with problems that are quite simple from a mathematical viewpoint.
+In a very entertaining and thought-provoking series of articles, Tversky and Kahneman ([1974](bibliography.md#bb1245), [1983](bibliography.md#bb1250), [1986](bibliography.md#bb1255)) show how people make irrational choices when faced with problems that are quite simple from a mathematical viewpoint.
 They liken these errors in choice to errors in visual perception caused by optical illusions.
 Even trained doctors and statisticians are subject to these errors.
 
@@ -1151,23 +1151,23 @@ Thus, the chance of actually having the disease given that one tests positive is
 Doctors are trained in this kind of analysis, but unfortunately many of them continue to reason more like Adrian than Dominique.
 
 In the late 1980s, the tide started to turn back to subjective Bayesian probability theory.
-[Cheeseman (1985)](B9780080571157500285.xhtml#bb0185) showed that, while Dempster-Shafer theory looks like it can, in fact it cannot help you make better decisions than probability theory.
-[Heckerman (1986)](B9780080571157500285.xhtml#bb0525) re-examined MYCIN's certainty factors, showing how they could be interpreted as probabilities.
-Judea [Pearl's 1988](B9780080571157500285.xhtml#bb0935) book is an eloquent defense of probability theory.
+[Cheeseman (1985)](bibliography.md#bb0185) showed that, while Dempster-Shafer theory looks like it can, in fact it cannot help you make better decisions than probability theory.
+[Heckerman (1986)](bibliography.md#bb0525) re-examined MYCIN's certainty factors, showing how they could be interpreted as probabilities.
+Judea [Pearl's 1988](bibliography.md#bb0935) book is an eloquent defense of probability theory.
 He shows that there are efficient algorithms for combining and propagating probabilities, as long as the network of interdependencies does not contain loops.
 It seems likely that uncertain reasoning in the 1990s will be based increasingly on Bayesian probability theory.
 
 ## 16.10 History and References
 
-The MYCIN project is well documented in [Buchanan and Shortliffe 1984](B9780080571157500285.xhtml#bb0145).
-An earlier book, [Shortliffe 1976](B9780080571157500285.xhtml#bb1100), is interesting mainly for historical purposes.
-Good introductions to expert systems in general include [Weiss and Kulikowski 1984](B9780080571157500285.xhtml#bb1365), [Waterman 1986](B9780080571157500285.xhtml#bb1345), [Luger and Stubblefield 1989](B9780080571157500285.xhtml#bb0760), and [Jackson 1990](B9780080571157500285.xhtml#bb0580).
+The MYCIN project is well documented in [Buchanan and Shortliffe 1984](bibliography.md#bb0145).
+An earlier book, [Shortliffe 1976](bibliography.md#bb1100), is interesting mainly for historical purposes.
+Good introductions to expert systems in general include [Weiss and Kulikowski 1984](bibliography.md#bb1365), [Waterman 1986](bibliography.md#bb1345), [Luger and Stubblefield 1989](bibliography.md#bb0760), and [Jackson 1990](bibliography.md#bb0580).
 
-Dempster-Shafer evidence theory is presented enthusiastically in [Gordon and Shortliffe 1984](B9780080571157500285.xhtml#bb0485) and in a critical light in [Pearl 1989](B9780080571157500285.xhtml#bb0940)/1978.
-Fuzzy set theory is presented in Zadeh 1979 and [Dubois and Prade 1988](B9780080571157500285.xhtml#bb0350).
+Dempster-Shafer evidence theory is presented enthusiastically in [Gordon and Shortliffe 1984](bibliography.md#bb0485) and in a critical light in [Pearl 1989](bibliography.md#bb0940)/1978.
+Fuzzy set theory is presented in Zadeh 1979 and [Dubois and Prade 1988](bibliography.md#bb0350).
 
-[Pearl (1988)](B9780080571157500285.xhtml#bb0935) captures most of the important points that lead to the renaissance of probability theory.
-[Shafer and Pearl 1990](B9780080571157500285.xhtml#bb1090) is a balanced collection of papers on all kinds of uncertain reasoning.
+[Pearl (1988)](bibliography.md#bb0935) captures most of the important points that lead to the renaissance of probability theory.
+[Shafer and Pearl 1990](bibliography.md#bb1090) is a balanced collection of papers on all kinds of uncertain reasoning.
 
 ## 16.11 Exercises
 

--- a/docs/chapter17.md
+++ b/docs/chapter17.md
@@ -1139,19 +1139,19 @@ Second, even when input checking is done, it is still up to the user to understa
 
 ## 17.5 History and References
 
-[Guzman (1968)](B9780080571157500285.xhtml#bb0500) was one of the first to consider the problem of interpreting line diagrams.
+[Guzman (1968)](bibliography.md#bb0500) was one of the first to consider the problem of interpreting line diagrams.
 He classified vertexes, and defined some heuristics for combining information from adjacent vertexes.
-[Huffman (1971)](B9780080571157500285.xhtml#bb0560) and [Clowes (1971)](B9780080571157500285.xhtml#bb0215) independently came up with more formal and complete analyses, and David [Waltz (1975)](B9780080571157500285.xhtml#bb1300) extended the analysis to handle shadows, and introduced the constraint propagation algorithm to cut down on the need for search.
+[Huffman (1971)](bibliography.md#bb0560) and [Clowes (1971)](bibliography.md#bb0215) independently came up with more formal and complete analyses, and David [Waltz (1975)](bibliography.md#bb1300) extended the analysis to handle shadows, and introduced the constraint propagation algorithm to cut down on the need for search.
 The algorithm is sometimes called "Waltz filtering" in his honor.
 With shadows and nontrihedral angles, there are thousands of vertex labelings instead of 18, but there are also more constraints, so the constraint propagation actually does better than it does in our limited world.
-Waltz's approach and the Huffman-Clowes labels are covered in most introductory AI books, including Rich and Knight 1990, [Charniak and McDermott 1985](B9780080571157500285.xhtml#bb0175), and [Winston 1984](B9780080571157500285.xhtml#bb1405).
-Waltz's original paper appears in *The Psychology of Computer Vision* ([Winston 1975](B9780080571157500285.xhtml#bb1400)), an influential volume collecting early work done at MIT.
-He also contributed a summary article on Waltz filtering ([Waltz 1990](B9780080571157500285.xhtml#bb1305)).
+Waltz's approach and the Huffman-Clowes labels are covered in most introductory AI books, including Rich and Knight 1990, [Charniak and McDermott 1985](bibliography.md#bb0175), and [Winston 1984](bibliography.md#bb1405).
+Waltz's original paper appears in *The Psychology of Computer Vision* ([Winston 1975](bibliography.md#bb1400)), an influential volume collecting early work done at MIT.
+He also contributed a summary article on Waltz filtering ([Waltz 1990](bibliography.md#bb1305)).
 
-Many introductory AI texts give vision short coverage, but [Charniak and McDermott (1985)](B9780080571157500285.xhtml#bb0175) and [Tanimoto (1990)](B9780080571157500285.xhtml#bb1220) provide good overviews of the field.
-[Zucker (1990)](B9780080571157500285.xhtml#bb1450) provides an overview of low-level vision.
+Many introductory AI texts give vision short coverage, but [Charniak and McDermott (1985)](bibliography.md#bb0175) and [Tanimoto (1990)](bibliography.md#bb1220) provide good overviews of the field.
+[Zucker (1990)](bibliography.md#bb1450) provides an overview of low-level vision.
 
-[Ramsey and Barrett (1987)](B9780080571157500285.xhtml#bb0975) give an implementation of a line-recognition program.
+[Ramsey and Barrett (1987)](bibliography.md#bb0975) give an implementation of a line-recognition program.
 It would make a good project to connect their program to the one presented in this chapter, and thereby go all the way from pixels to 3-D descriptions.
 
 ## 17.6 Exercises
@@ -1167,7 +1167,7 @@ Write a function that takes a list of faces and a diagram and produces a list of
 
 **Exercise  17.3 [d]** Extend the system to include quad-hedral vertexes and/or shadows.
 There is no conceptual difficulty in this, but it is a very demanding task to find all the possible vertex types and labelings for them.
-Consult [Waltz 1975](B9780080571157500285.xhtml#bb1300).
+Consult [Waltz 1975](bibliography.md#bb1300).
 
 **Exercise  17.4 [d]** Implement a program to recognize lines from pixels.
 

--- a/docs/chapter18.md
+++ b/docs/chapter18.md
@@ -1453,7 +1453,7 @@ The search is the same except that nodes are passed around instead of boards, an
 ```
 
 (Note the use of the function `map-into`.
-This is part of ANSI Common Lisp, but if it is not a part of your implementation, a definition is provided on [page 857](B9780080571157500248.xhtml#p857).)
+This is part of ANSI Common Lisp, but if it is not a part of your implementation, a definition is provided on [page 857](chapter24.md#p857).)
 
 The following table compares the performance of the random-ordering strategy, the sorted-ordering strategy and the static-ordering strategy in the course of a single game.
 All strategies search 6 ply deep.
@@ -1606,7 +1606,7 @@ The times for full minimax are estimates based on the number of boards per secon
 
 The algorithm in this section just keeps track of one killer move.
 It is of course possible to keep track of more than one.
-The Othello program Bill ([Lee and Mahajan 1990b](B9780080571157500285.xhtml#bb0715)) merges the idea of killer moves with legal move generation: it keeps a list of possible moves at each level, sorted by their value.
+The Othello program Bill ([Lee and Mahajan 1990b](bibliography.md#bb0715)) merges the idea of killer moves with legal move generation: it keeps a list of possible moves at each level, sorted by their value.
 The legal move generator then goes down this list in sorted order.
 
 It should be stressed once again that all this work on alpha-beta cutoffs, ordering, and killer moves has not made any change at all in the moves that are selected.
@@ -1618,9 +1618,10 @@ As mentioned in the introduction, the unpredictability of Othello makes it a dif
 In fact, in 1981 the reigning champion, Jonathan Cerf, proclaimed "In my opinion the top programs ... are now equal (if not superior) to the best human players." In discussing Rosenbloom's Iago program (1982), Cerf went on to say "I understand Paul Rosenbloom is interested in arranging a match against me.
 Unfortunately my schedule is very full, and I'm going to see that it remains that way for the foreseeable future."
 
-In 1989, another program, Bill ([Lee and Mahajan 1990](B9780080571157500285.xhtml#bb0715)) beat the highest rated American Othello player, Brian Rose, by a score of 56-8.
+In 1989, another program, Bill ([Lee and Mahajan 1990](bibliography.md#bb0715)) beat the highest rated American Othello player, Brian Rose, by a score of 56-8.
 Bill's evaluation function is fast enough to search 6-8 ply under tournament conditions, yet it is so accurate that it beats its creator, Kai-Fu Lee, searching only 1 ply.
-(However, Lee is only a novice Othello player; his real interest is in speech recognition; see [Waibel and Lee 1991](B9780080571157500285.xhtml#bb1285).) There are other programs that also play at a high level, but they have not been written up in the AI literature as Iago and Bill have.
+(However, Lee is only a novice Othello player; his real interest is in speech recognition; see [Waibel and Lee 1991](bibliography.md#bb1285).)
+There are other programs that also play at a high level, but they have not been written up in the AI literature as Iago and Bill have.
 
 In this section we present an evaluation function based on Iago's, although it also contains elements of Bill, and of an evaluation function written by Eric Wefald in 1989.
 The evaluation function makes use of two main features: *mobility and edge stability*.
@@ -1970,7 +1971,7 @@ It will be able to store this more compactly and `load` it back in more quickly 
 
 Now we have a measure of the three factors: current mobility, potential mobility, and edge stability.
 All that remains is to find a good way to combine them into a single evaluation metric.
-The combination function used by [Rosenbloom (1982)](B9780080571157500285.xhtml#bb1000) is a linear combination of the three factors, but each factor's coefficient is dependent on the move number.
+The combination function used by [Rosenbloom (1982)](bibliography.md#bb1000) is a linear combination of the three factors, but each factor's coefficient is dependent on the move number.
 Rosenbloom's features are normalized to the range [-1000, 1000]; we normalize to the range [-1, 1] by doing a division after multiplying by the coefficient.
 That allows us to use fixnums for the coefficients.
 Since our three factors are not calculated in quite the same way as Rosenbloom's, it is not surprising that his coefficients are not the best for our program.
@@ -2023,7 +2024,7 @@ Most of the following techniques were incorporated, or at least considered and r
 We have seen that the average branching factor for Othello is about 10.
 This means that searching to depth *n* + 1 takes roughly 10 times longer than search to depth *n*.
 Thus, we should be willing to go to a lot of overhead before we search one level deeper, to assure two things: that search will be done efficiently, and that we won't forfeit due to running out of time.
-A by-now familiar technique, iterative deepening (see [chapters 6](B9780080571157500066.xhtml) and [14](B9780080571157500145.xhtml)), serves both these goals.
+A by-now familiar technique, iterative deepening (see [chapters 6](chapter6.md) and [14](chapter14.md)), serves both these goals.
 
 Iterative deepening is used as follows.
 The strategy determines how much of the remaining time to allocate to each move.
@@ -2073,7 +2074,7 @@ If the actual value is not in the range, then the value returned will reflect th
 This is called aspiration search, because we aspire to find a value within a given window.
 If the window is chosen well, then often we will succeed and will have saved some search time.
 
-[Pearl (1984)](B9780080571157500285.xhtml#bb0930) suggests an alternative called zero-window search.
+[Pearl (1984)](bibliography.md#bb0930) suggests an alternative called zero-window search.
 At each level, the first possible move, which we'll call *m*, is searched using a reasonably wide window to determine its exact value, which we'll call *v*.
 Then the remaining possible moves are searched using *v* as both the lower and upper bounds of the window.
 Thus, the result of the search will tell if each subsequent move is better or worse than *m*, but won't tell how much better or worse.
@@ -2101,7 +2102,7 @@ It can consider more than one move by the opponent, depending on how much time i
 ### Hashing and Opening Book Moves
 
 We have been treating the search space as a tree, but in general it is a directed acyclic graph (dag): there may be more than one way to reach a particular position, but there won't be any loops, because every move adds a new piece.
-This raises the question we explored briefly in [section 6.4](B9780080571157500066.xhtml#s0025): should we treat the search space as a tree or a graph?
+This raises the question we explored briefly in [section 6.4](chapter6.md#s0025): should we treat the search space as a tree or a graph?
 By treating it as a graph we eliminate duplicate evaluations, but we have the overhead of storing all the previous positions, and of checking to see if a new position has been seen before.
 The decision must be based on the proportion of duplicate positions that are actually encountered in play.
 One compromise solution is to store in a hash table a partial encoding of each position, encoded as, say, a single fixnum (one word) instead of the seven or so words needed to represent a full board.
@@ -2132,7 +2133,7 @@ That is, at every tick of the clock, we need to decide if it is better to stop a
 It will be better to compute more only in the case where we eventually choose a better move; it will be better to stop and play only in the case where we would otherwise forfeit due to time constraints, or be forced to make poor choices later in the game.
 An algorithm that includes computation as a possible move is called a metareasoning system, because it reasons about how much to reason.
 
-[Russell and Wefald (1989)](B9780080571157500285.xhtml#bb1025) present an approach based on this view.
+[Russell and Wefald (1989)](bibliography.md#bb1025) present an approach based on this view.
 In addition to an evaluation function, they assume a variance function, which gives an estimate of how much a given position's true value is likely to vary from its static value.
 At each step, their algorithm compares the value and variance of the best move computed so far and the second best move.
 If the best move is clearly better than the second best (taking variance into account), then there is no point computing any more.
@@ -2149,7 +2150,7 @@ The metareasoning algorithm is predicated on devoting time to just this case.
 ### Learning
 
 From the earliest days of computer game playing, it was realized that a championship program would need to learn to improve itself.
-[Samuel (1959)](B9780080571157500285.xhtml#bb1040) describes a program that plays checkers and learns to improve its evaluation function.
+[Samuel (1959)](bibliography.md#bb1040) describes a program that plays checkers and learns to improve its evaluation function.
 The evaluation function is a linear combination of features, such as the number of pieces for each player, the number of kings, the number of possible forks, and so on.
 Learning is done by a hill-climbing search procedure: change one of the coefficients for one of the features at random, and then see if the changed evaluation function is better than the original one.
 
@@ -2177,7 +2178,7 @@ To increase the chances of this, it is a good idea to allow for mutations: rando
 
 ## 18.14 History and References
 
-[Lee and Mahajan (1986,](B9780080571157500285.xhtml#bb0710)[1990)](B9780080571157500285.xhtml#bb0715) present the current top Othello program, Bill.
+[Lee and Mahajan (1986,](bibliography.md#bb0710)[1990)](bibliography.md#bb0715) present the current top Othello program, Bill.
 Their description outlines all the techniques used but does not go into enough detail to allow the reader to reconstruct the program.
 Bill is based in large part on Rosenbloom's Iago program.
 Rosenbloom's article (1982) is more thorough.
@@ -2186,24 +2187,24 @@ The presentation in this chapter is based largely on this article, although it a
 The journal *Othello Quarterly* is the definitive source for reports on both human and computer Othello games and strategies.
 
 The most popular game for computer implementation is chess.
-[Shannon (1950a,](B9780080571157500285.xhtml#bb1070)[b)](B9780080571157500285.xhtml#bb1075) speculated that a computer might play chess.
+[Shannon (1950a,](bibliography.md#bb1070)[b)](bibliography.md#bb1075) speculated that a computer might play chess.
 In a way, this was one of the boldest steps in the history of AI.
 Today, writing a chess program is a challenging but feasible project for an undergraduate.
 But in 1950, even suggesting that such a program might be possible was a revolutionary step that changed the way people viewed these arithmetic calculating devices.
 Shannon introduced the ideas of a game tree search, minimaxing, and evaluation functions-ideas that remain intact to this day.
-[Marsland (1990)](B9780080571157500285.xhtml#bb0770) provides a good short introduction to computer chess, and David Levy has two books on the subject (1976, 1988).
+[Marsland (1990)](bibliography.md#bb0770) provides a good short introduction to computer chess, and David Levy has two books on the subject (1976, 1988).
 It was Levy, an international chess master, who in 1968 accepted a bet from John McCarthy, Donald Michie, and others that a computer chess program would not beat him in the next ten years.
 Levy won the bet.
 Levy's *Heuristic Programming* (1990) and *Computer Games* (1988) cover a variety of computer game playing programs.
-The studies by [DeGroot (1965,](B9780080571157500285.xhtml#bb0305)[1966)](B9780080571157500285.xhtml#bb0310) give a fascinating insight into the psychology of chess masters.
+The studies by [DeGroot (1965,](bibliography.md#bb0305)[1966)](bibliography.md#bb0310) give a fascinating insight into the psychology of chess masters.
 
-[Knuth and Moore (1975)](B9780080571157500285.xhtml#bb0630) analyze the alpha-beta algorithm, and Pearl's book *Heuristics* (1984) covers all kinds of heuristic search, games included.
+[Knuth and Moore (1975)](bibliography.md#bb0630) analyze the alpha-beta algorithm, and Pearl's book *Heuristics* (1984) covers all kinds of heuristic search, games included.
 
-[Samuel (1959)](B9780080571157500285.xhtml#bb1040) is the classic work on learning evaluation function parameters.
+[Samuel (1959)](bibliography.md#bb1040) is the classic work on learning evaluation function parameters.
 It is based on the game of checkers.
-[Lee and Mahajan (1990)](B9780080571157500285.xhtml#bb0715) present an alternative learning mechanism, using Bayesian classification to learn an evaluation function that optimally distinguishes winning positions from losing positions.
+[Lee and Mahajan (1990)](bibliography.md#bb0715) present an alternative learning mechanism, using Bayesian classification to learn an evaluation function that optimally distinguishes winning positions from losing positions.
 Genetic algorithms are discussed by L.
-[Davis (1987,](B9780080571157500285.xhtml#bb0280) [1991)](B9780080571157500285.xhtml#bb0285) and [Goldberg (1989)](B9780080571157500285.xhtml#bb0480).
+[Davis (1987,](bibliography.md#bb0280) [1991)](bibliography.md#bb0285) and [Goldberg (1989)](bibliography.md#bb0480).
 
 ## 18.15 Exercises
 
@@ -2223,8 +2224,8 @@ What other efficiency measures can you take?
 
 **Exercise  18.7 [h]** Implement zero-window search, as described in [section 18.13](#s0085).
 
-**Exercise  18.8 [d]** Read the references on Bill ([Lee and Mahajan 1990](B9780080571157500285.xhtml#bb0715), and [1986](B9780080571157500285.xhtml#bb0710) if you can get it), and reimplement Bill's evaluation function as best you can, using the table-based approach.
-It will also be helpful to read [Rosenbloom 1982](B9780080571157500285.xhtml#bb1000).
+**Exercise  18.8 [d]** Read the references on Bill ([Lee and Mahajan 1990](bibliography.md#bb0715), and [1986](bibliography.md#bb0710) if you can get it), and reimplement Bill's evaluation function as best you can, using the table-based approach.
+It will also be helpful to read [Rosenbloom 1982](bibliography.md#bb1000).
 
 **Exercise  18.9 [d]** Improve the evaluation function by tuning the parameters, using one of the techniques described in [section 18.13](#s0085).
 

--- a/docs/chapter19.md
+++ b/docs/chapter19.md
@@ -42,7 +42,7 @@ In general, there may be several possible derivations, in which case we say the 
 In certain circles, the term "parse" means to arrive at an understanding of a sentence's meaning, not just its grammatical form.
 We will attack that more difficult question later.
 
-We start with the grammar defined on [page 39](B9780080571157500029.xhtml#p39) for the generate program:
+We start with the grammar defined on [page 39](chapter2.md#p39) for the generate program:
 
 ```lisp
 (defvar *grammar* nil "The grammar used by GENERATE.")
@@ -84,7 +84,7 @@ To emphasize this, I include "noun" and "verb" as nouns in the grammar `*grammar
 
 I also define the data types `rule, parse`, and `tree`, and some functions for getting at the rules.
 Rules are defined as structures of type list with three slots: the left-hand side, the arrow (which should always be represented as the literal ->) and the right-hand side.
-Compare this to the treatment on [page 40](B9780080571157500029.xhtml#p40).
+Compare this to the treatment on [page 40](chapter2.md#p40).
 
 ```lisp
 (defstruct (rule (:type list)) lhs -> rhs sem)
@@ -989,13 +989,13 @@ Furthermore, *unification grammars* allow a natural way of attaching semantics t
 ## 19.8 History and References
 
 There is a class of parsing algorithms known as *chart parsers* that explicitly cache partial parses and reuse them in constructing larger parses.
-Earley's algorithm (1970) is the first example, and Martin [Kay (1980)](B9780080571157500285.xhtml#bb0605) gives a good overview of the field and introduces a data structure, the *chart*, for storing substrings of a parse.
-[Winograd (1983)](B9780080571157500285.xhtml#bb1395) gives a complex (five-page) specification of a chart parser.
+Earley's algorithm (1970) is the first example, and Martin [Kay (1980)](bibliography.md#bb0605) gives a good overview of the field and introduces a data structure, the *chart*, for storing substrings of a parse.
+[Winograd (1983)](bibliography.md#bb1395) gives a complex (five-page) specification of a chart parser.
 None of these authors have noticed that one can achieve the same results by augmenting a simple (one-page) parser with memoization.
 In fact, it is possible to write a top-down parser that is even more succinct.
 (See [exercise 19.3](#p2455) below.)
 
-For a general overview of natural language processing, my preferences (in order) are [Allen 1987](B9780080571157500285.xhtml#bb0030), [Winograd 1983](B9780080571157500285.xhtml#bb1395) or [Gazdar and Mellish 1989](B9780080571157500285.xhtml#bb0445).
+For a general overview of natural language processing, my preferences (in order) are [Allen 1987](bibliography.md#bb0030), [Winograd 1983](bibliography.md#bb1395) or [Gazdar and Mellish 1989](bibliography.md#bb0445).
 
 ## 19.9 Exercises
 
@@ -1182,5 +1182,5 @@ Some erroneous expressions are underspecified and may return different results i
 <a id="fn19-2"></a><sup>[2](#tfn19-2)</sup>
 The number of parses of sentences of this kind is the same as the number of bracketings of a arithmetic expression, or the number of binary trees with a given number of leaves.
 The resulting sequence (1, 2, 5, 14, 42, ...) is known as the Catalan Numbers.
-This kind of ambiguity is discussed by [Church and Patil (1982)](B9780080571157500285.xhtml#bb0200) in their article *Coping with Syntactic Ambiguity, or How to Put the Block in the Box on the Table.*
+This kind of ambiguity is discussed by [Church and Patil (1982)](bibliography.md#bb0200) in their article *Coping with Syntactic Ambiguity, or How to Put the Block in the Box on the Table.*
 

--- a/docs/chapter2.md
+++ b/docs/chapter2.md
@@ -12,7 +12,7 @@ Rather, you must hear and speak (or read and write) the language to gain profici
 The same is true for learning computer languages.
 
 This chapter shows how to combine the basic functions and special forms of Lisp into a complete program.
-If you can learn how to do that, then acquiring the remaining vocabulary of Lisp (as outlined in chapter 3) will be easy.
+If you can learn how to do that, then acquiring the remaining vocabulary of Lisp (as outlined in [chapter 3](chapter3.md)) will be easy.
 
 ## 2.1 A Grammar for a Subset of English
 

--- a/docs/chapter20.md
+++ b/docs/chapter20.md
@@ -28,7 +28,7 @@ The rule says that a given string of words `?s` is a sentence if there is a stri
 Logically, this is fine, and it would work as a program to generate random sentences.
 However, it is a very inefficient program for parsing sentences.
 It will consider all possible noun phrases and verb phrases, without regard to the input words.
-Only when it gets to the concat goal (defined on [page 411](B9780080571157500121.xhtml#p411)) will it test to see if the two constituents can be concatenated together to make up the input string.
+Only when it gets to the concat goal (defined on [page 411](chapter12.md#p411)) will it test to see if the two constituents can be concatenated together to make up the input string.
 Thus, a better order of evaluation for parsing is:
 
 ```lisp
@@ -71,7 +71,8 @@ A sample query would be `(?- (S (The boy ate the apple) ())).` With suitable def
 
 Another way of reading the goal `(NP ?s0 ?sl)`, for example, is as "`IS` the list `?s0` minus the list `?sl` a noun phrase?" In this case, `?s0` minus `?sl` is the list `(The boy)`.
 The combination of two arguments, an input list and an output list, is often called a *difference list*, to emphasize this interpretation.
-More generally, the combination of an input parameter and output parameter is called an *accumulator.* Accumulators, particularly difference lists, are an important technique throughout logic programming and are also used in functional programming, as we saw on [page 63](B9780080571157500030.xhtml#p63).
+More generally, the combination of an input parameter and output parameter is called an *accumulator.*
+Accumulators, particularly difference lists, are an important technique throughout logic programming and are also used in functional programming, as we saw on [page 63](chapter3.md#p63).
 
 In our rule for `S`, the concatenation of difference lists was implicit.
 If we prefer, we could define a version of `concat` for difference lists and call it explicitly:
@@ -1171,18 +1172,18 @@ His *metamorphosis grammar* formalism was more expressive but much less efficien
 The grammar in [section 20.4](#s0025) is essentially the same as the one presented in Fernando Pereira and David H.
 D.
 Warren's 1980 paper, which introduced the Definite Clause Grammar formalism as it is known today.
-The two developed a much more substantial grammar and used it in a very influential question-answering system called Chat-80 ([Warren and Pereira, 1982](B9780080571157500285.xhtml#bb1340)).
+The two developed a much more substantial grammar and used it in a very influential question-answering system called Chat-80 ([Warren and Pereira, 1982](bibliography.md#bb1340)).
 Pereira later teamed with Stuart Shieber on an excellent book covering logic grammars in more depth: *Prolog and Natural-Language Analysis* (1987).
 The book has many strong points, but unfortunately it does not present a grammar anywhere near as complete as the Chat-80 grammar.
 
 The idea of a compositional semantics based on mathematical logic owes much to the work of the late linguist Richard Montague.
-The introduction by [Dowty, Wall, and Peters (1981)](B9780080571157500285.xhtml#bb0335) and the collection by [Rich Thomason (1974)](B9780080571157500285.xhtml#bb1235) cover Montague's approach.
+The introduction by [Dowty, Wall, and Peters (1981)](bibliography.md#bb0335) and the collection by [Rich Thomason (1974)](bibliography.md#bb1235) cover Montague's approach.
 
 The grammar in [section 20.5](#s0030) is based loosely on Michael McCord's modular logic grammar, as presented in [Walker et al.
-1990](B9780080571157500285.xhtml#bb1295).
+1990](bibliography.md#bb1295).
 
 It should be noted that logic grammars are by no means the only approach to natural language processing.
-[Woods (1970)](B9780080571157500285.xhtml#bb1425) presents an approach based on the *augmented transition network*, or ATN.
+[Woods (1970)](bibliography.md#bb1425) presents an approach based on the *augmented transition network*, or ATN.
 A transition network is like a context-free grammar.
 The *augmentation* is a way of manipulating features and semantic values.
 This is just like the extra arguments in DCGs, except that the basic operations are setting and testing variables rather than unification.
@@ -1190,7 +1191,7 @@ So the choice between ATNs and DCGs is largely a matter of what programming appr
 My feeling is that unification is a more suitable primitive than assignment, so I chose to present DCGs, even though this required bringing in Prolog's backtracking and unification mechanisms.
 
 In either approach, the same linguistic problems must be addressed-agreement, long-distance dependencies, topicalization, quantifier-scope ambiguity, and so on.
-Comparing [Woods's (1970)](B9780080571157500285.xhtml#bb1425) ATN grammar to [Pereira and Warren's (1980)](B9780080571157500285.xhtml#bb0950) DCG grammar, the careful reader will see that the solutions have much in common.
+Comparing [Woods's (1970)](bibliography.md#bb1425) ATN grammar to [Pereira and Warren's (1980)](bibliography.md#bb0950) DCG grammar, the careful reader will see that the solutions have much in common.
 The analysis is more important than the notation, as it should be.
 
 ## 20.9 Exercises

--- a/docs/chapter21.md
+++ b/docs/chapter21.md
@@ -1418,7 +1418,7 @@ A disambiguation procedure should be equipped to weed out such duplicates.
 
 ## 21.15 History and References
 
-[Chapter 20](B9780080571157500200.xhtml) provides some basic references on natural language.
+[Chapter 20](chapter20.md) provides some basic references on natural language.
 Here we will concentrate on references that provide:
 
 1.  A comprehensive grammar of English.
@@ -1426,20 +1426,20 @@ Here we will concentrate on references that provide:
 2.  A complete implementation.
 
 There are a few good textbooks that partially address both issues.
-Both [Winograd (1983)](B9780080571157500285.xhtml#bb1395) and [Allen (1987)](B9780080571157500285.xhtml#bb0030) do a good job of presenting the major grammatical features of English and discuss implementation techniques, but they do not provide actual code.
+Both [Winograd (1983)](bibliography.md#bb1395) and [Allen (1987)](bibliography.md#bb0030) do a good job of presenting the major grammatical features of English and discuss implementation techniques, but they do not provide actual code.
 
 There are also a few textbooks that concentrate on the second issue.
-[Ramsey and Barrett (1987)](B9780080571157500285.xhtml#bb0975) and [Walker et al.
-(1990)](B9780080571157500285.xhtml#bb1295) provide chapter-length implementations at about the same level of detail as this chapter.
+[Ramsey and Barrett (1987)](bibliography.md#bb0975) and [Walker et al.
+(1990)](bibliography.md#bb1295) provide chapter-length implementations at about the same level of detail as this chapter.
 Both are recommended.
-[Pereira and Shieber 1987](B9780080571157500285.xhtml#bb0945) and [Gazdar and Mellish 1989](B9780080571157500285.xhtml#bb0445) are book-length treatments, but because they cover a variety of parsing techniques rather than concentrating on one in depth, they are actually less comprehensive.
+[Pereira and Shieber 1987](bibliography.md#bb0945) and [Gazdar and Mellish 1989](bibliography.md#bb0445) are book-length treatments, but because they cover a variety of parsing techniques rather than concentrating on one in depth, they are actually less comprehensive.
 
 Several linguists have made serious attempts at addressing the first issue.
 The largest is the aptly named A *Comprehensive Grammar of Contemporary English* by Quirk, Greenbaum, Leech and Svartik (1985).
 More manageable (although hardly concise) is their abridged edition, *A Concise Grammar of Contemporary English.* Both editions contain a gold mine of examples and facts about the English langauge, but the authors do not attempt to write rigorous rules.
-[Harris (1982)](B9780080571157500285.xhtml#bb0510) and [Huddleston (1984)](B9780080571157500285.xhtml#bb0555) offer less complete grammars with greater linguistic rigor.
+[Harris (1982)](bibliography.md#bb0510) and [Huddleston (1984)](bibliography.md#bb0555) offer less complete grammars with greater linguistic rigor.
 
-Naomi [Sager (1981)](B9780080571157500285.xhtml#bb1035) presents the most complete computerized grammar ever published.
+Naomi [Sager (1981)](bibliography.md#bb1035) presents the most complete computerized grammar ever published.
 The grammar is separated into a simple, neat, context-free component and a rather baroque augmentation that manipulates features.
 
 ## 21.16 Exercises

--- a/docs/chapter22.md
+++ b/docs/chapter22.md
@@ -367,7 +367,7 @@ The final three syntactic extensions are unique to Scheme:
 In its first form, it assigns a value to a variable.
 Since there are no special variables in Scheme, this is no different than using `set!`.
 (There is a difference when the `define` is nested inside another definition, but that is not yet considered.) In the second form, it defines a function.
-`delay` is used to delay evaluation, as described in [section 9.3](B9780080571157500091.xhtml#s0020), page 281.
+`delay` is used to delay evaluation, as described in [section 9.3](chapter9.md#s0020), page 281.
 `letrec` is similar to `let`.
 The difference is that all the *init* forms are evaluated in an environment that includes all the *vars*.
 Thus, `letrec` can be used to define local recursive functions, just as `labels` does in Common Lisp.
@@ -996,7 +996,7 @@ Once the working of `call/cc` is understood, the implementation is obvious:
 ## 22.6 History and References
 
 Lisp interpreters and AI have a long history together.
-MIT AI Lab Memo No. 1 ([McCarthy 1958](B9780080571157500285.xhtml#bb0790)) was the first paper on Lisp.
+MIT AI Lab Memo No. 1 ([McCarthy 1958](bibliography.md#bb0790)) was the first paper on Lisp.
 McCarthy's students were working on a Lisp compiler, had written certain routines-`read`, `print`, etc. - in assembly language, and were trying to develop a full Lisp interpreter in assembler.
 Sometime around the end of 1958, McCarthy wrote a theoretical paper showing that Lisp was powerful enough to write the universal function, `eval`.
 A programmer on the project, Steve Russell, saw the paper, and, according to McCarthy:
@@ -1008,26 +1008,26 @@ That is, he compiled the `eval` in my paper into 704 machine code fixing bugs an
 
 So the first Lisp interpreter was the result of a programmer ignoring his boss's advice.
 The first compiler was for the Lisp 1.5 system ([McCarthy et al.
-1962](B9780080571157500285.xhtml#bb0815)).
+1962](bibliography.md#bb0815)).
 The compiler was written in Lisp; it was probably the first compiler written in its own language.
 
 Allen's *Anatomy of Lisp* (1978) was one of the first overviews of Lisp implementation techniques, and it remains one of the best.
 However, it concentrates on the dynamic-scoping Lisp dialects that were in use at the time.
-The more modern view of a lexically scoped Lisp was documented in an influential pair of papers by Guy Steele ([1976a](B9780080571157500285.xhtml#bb1130),[b](B9780080571157500285.xhtml#bb1135)).
+The more modern view of a lexically scoped Lisp was documented in an influential pair of papers by Guy Steele ([1976a](bibliography.md#bb1130),[b](bibliography.md#bb1135)).
 His papers "Lambda: the ultimate goto" and "Compiler optimization based on viewing lambda as rename plus goto" describe properly tail-recursive interpreters and compilers.
 
 The Scheme dialect was invented by Gerald Sussman and Guy Steele around 1975 (see their MIT AI Memo 349).
 The *Revised*<sup>4</sup> *Report on the Algorithmic Language Scheme* ([Clinger et al.
-1991](B9780080571157500285.xhtml#bb0205)) is the definitive reference manual for the current version of Scheme.
+1991](bibliography.md#bb0205)) is the definitive reference manual for the current version of Scheme.
 
-[Abelson and Sussman (1985)](B9780080571157500285.xhtml#bb0010) is probably the best introduction to computer science ever written.
+[Abelson and Sussman (1985)](bibliography.md#bb0010) is probably the best introduction to computer science ever written.
 It may or may not be a coincidence that it uses Scheme as the programming language.
 It includes a Scheme interpreter.
 Winston and Horn's *Lisp* (1989) also develops a Lisp interpreter.
 
-The `amb` operator for nondeterministic choice was proposed by [John McCarthy (1963)](B9780080571157500285.xhtml#bb0800) and used in SCHEMER ([Zabih et al.
-1987](B9780080571157500285.xhtml#bb1440)), a nondeterministic Lisp.
-[Ruf and Weise (1990)](B9780080571157500285.xhtml#bb1015) present another implementation of backtracking in Scheme that incorporates all of logic programming.
+The `amb` operator for nondeterministic choice was proposed by [John McCarthy (1963)](bibliography.md#bb0800) and used in SCHEMER ([Zabih et al.
+1987](bibliography.md#bb1440)), a nondeterministic Lisp.
+[Ruf and Weise (1990)](bibliography.md#bb1015) present another implementation of backtracking in Scheme that incorporates all of logic programming.
 
 ## 22.7 Exercises
 
@@ -1273,4 +1273,4 @@ However, `defstruct` concatenates `-p` in all its predicates, regardless of the 
 although inefficient
 
 <a id="fn22-3"></a><sup>[3](#tfn22-3)</sup>
-McCarthy's words from a talk on the history of Lisp, 1974, recorded by [Stoyan (1984)](B9780080571157500285.xhtml#bb1205).
+McCarthy's words from a talk on the history of Lisp, 1974, recorded by [Stoyan (1984)](bibliography.md#bb1205).

--- a/docs/chapter23.md
+++ b/docs/chapter23.md
@@ -127,7 +127,7 @@ The difference is that each case generates code rather than evaluating a subexpr
 
 ```
 
-The compiler `comp` has the same nine cases-in fact the exact same structure-as the interpreter `interp` from [chapter 22](B9780080571157500224.xhtml).
+The compiler `comp` has the same nine cases-in fact the exact same structure-as the interpreter `interp` from [chapter 22](chapter22.md).
 Each case is slightly more complex, so the three main cases have been made into separate functions: `comp-begin`, `comp-if`, and `comp-lambda.` A `begin` expression is compiled by compiling each argument in turn but making sure to pop each value but the last off the stack after it is computed.
 The last element in the `begin` stays on the stack as the value of the whole expression.
 Note that the function `gen` generates a single instruction (actually a list of one instruction), and `seq` makes a sequence of instructions out of two or more subsequences.
@@ -437,7 +437,7 @@ An alternative function-calling protocol involves pushing the return address bef
 Such an optimization looks like a small gain; we basically eliminate a single instruction.
 In fact, the implications of this new protocol are enormous: we can now invoke a recursive function to an arbitrary depth without growing the stack at all-as long as the recursive call is the last statement in the function (or in a branch of the function when there are conditionals).
 A function that obeys this constraint on its recursive calls is known as a *properly tail-recursive* function.
-This subject was discussed in [section 22.3.](B9780080571157500224.xhtml#s0020)
+This subject was discussed in [section 22.3.](chapter22.md#s0020)
 
 All the examples so far have only dealt with global variables.
 Here's an example using local variables:
@@ -1163,8 +1163,8 @@ There are several paths we could pursue: we could implement the machine in hardw
 Each of these approaches has been taken in the past.
 
 **Hardware.** If the abstract machine is simple enough, it can be implemented directly in hardware.
-The Scheme-79 and Scheme-81 Chips ([Steele and Sussman 1980](B9780080571157500285.xhtml#bb1180); [Batali et al.
-1982](B9780080571157500285.xhtml#bb0070)) were VLSI implementations of a machine designed specifically to run Scheme.
+The Scheme-79 and Scheme-81 Chips ([Steele and Sussman 1980](bibliography.md#bb1180); [Batali et al.
+1982](bibliography.md#bb0070)) were VLSI implementations of a machine designed specifically to run Scheme.
 
 **Macro-Assembler.** In the translation or macro-assembler approach, each instruction in the abstract machine language is translated into one or more instructions in the host computer's instruction set.
 This can be done either directly or by generating assembly code and passing it to the host computer's assembler.
@@ -1794,13 +1794,13 @@ Those who do define local functions tend not to use already established names li
 ## 23.6 History and References
 
 Guy Steele's 1978 MIT master's thesis on the language Scheme, rewritten as Steele 1983, describes an innovative and influential compiler for Scheme, called RABBIT.<a id="tfn23-2"></a><sup>[2](#fn23-2)</sup>
-A good article on an "industrial-strength" Scheme compiler based on this approach is described in [Kranz et al.'s 1986](B9780080571157500285.xhtml#bb0675) paper on ORBIT, the compiler for the T dialect of Scheme.
+A good article on an "industrial-strength" Scheme compiler based on this approach is described in [Kranz et al.'s 1986](bibliography.md#bb0675) paper on ORBIT, the compiler for the T dialect of Scheme.
 
 Abelson and Sussman's *Structure and Interpretation of Computer Programs* (1985) contains an excellent chapter on compilation, using slightly different techniques and compiling into a somewhat more confusing machine language.
-Another good text is [John Allen's *Anatomy of Lisp* (1978)](B9780080571157500285.xhtml#bb0040).
+Another good text is [John Allen's *Anatomy of Lisp* (1978)](bibliography.md#bb0040).
 It presents a very clear, simple compiler, although it is for an older, dynamically scoped dialect of Lisp and it does not address tail-recursion or `call/cc`.
 
-The peephole optimizer described here is based on the one in [Masinter and Deutsch 1980](B9780080571157500285.xhtml#bb0780).
+The peephole optimizer described here is based on the one in [Masinter and Deutsch 1980](bibliography.md#bb0780).
 
 ## 23.7 Exercises
 
@@ -1810,7 +1810,7 @@ How could you make `scheme-read` account for this?
 
 **Exercise  23.4 [m]** Is it possible to make the core Scheme language even smaller, by eliminating any of the five special forms `(quote, begin, set!, if, lambda)` and replacing them with macros?
 
-**Exercise  23.5 [m]** Add the ability to recognize internal defines (see [page 779](B9780080571157500224.xhtml#p779)).
+**Exercise  23.5 [m]** Add the ability to recognize internal defines (see [page 779](chapter22.md#p779)).
 
 **Exercise  23.6 [h]** In `comp-if` we included a special case for `(if t x y)` and `(if nil x y)`.
 But there are other cases where we know the value of the predicate.

--- a/docs/chapter24.md
+++ b/docs/chapter24.md
@@ -838,7 +838,7 @@ Here's roughly what we want:
 
 where `g001` is a new symbol, to avoid conflicts with the `x` or with symbols in the body.
 Normally, we generate macro bodies using backquotes, but if the macro body itself has a backquote, then what?
-It is possible to nest backquotes (and [appendix C](B9780080571157500273.xhtml) of *Common Lisp the Language*, 2d edition has a nice discussion of doubly and triply nested backquotes), but it certainly is not trivial to understand.
+It is possible to nest backquotes (and appendix C of *Common Lisp the Language*, 2d edition has a nice discussion of doubly and triply nested backquotes), but it certainly is not trivial to understand.
 I recommend replacing the inner backquote with its equivalent using `list` and `quote`:
 
 ```lisp

--- a/docs/chapter24.md
+++ b/docs/chapter24.md
@@ -13,7 +13,7 @@ A *package* is a symbol table that maps from strings to symbols named by those s
 When read is confronted with a sequence of characters like `list`, it uses the symbol table to determine that this refers to the symbol `list`.
 The important point is that every use of the symbol name `list` refers to the same symbol.
 That makes it easy to refer to predefined symbols, but it also makes it easy to introduce unintended name conflicts.
-For example, if I wanted to hook up the `emycin` expert system from [chapter 16](B9780080571157500169.xhtml) with the parser from [chapter 19](B9780080571157500194.xhtml), there would be a conflict because both programs use the symbol `defrule` to mean different things.
+For example, if I wanted to hook up the `emycin` expert system from [chapter 16](chapter16.md) with the parser from [chapter 19](chapter19.md), there would be a conflict because both programs use the symbol `defrule` to mean different things.
 
 Common Lisp uses the package system to help resolve such conflicts.
 Instead of a single symbol table, Common Lisp allows any number of packages.
@@ -81,7 +81,7 @@ Also note that ANSI renames the `lisp package` as `common-lisp`.
  (:export emycin defrule defcontext defparm yes/no yes no is))
 ```
 
-For more on packages and building systems, see [section 25.16](B978008057115750025X.xhtml#s0110) or *Common Lisp the Language.*
+For more on packages and building systems, see [section 25.16](chapter25.md#s0110) or *Common Lisp the Language.*
 
 ### The Seven Name Spaces
 
@@ -231,7 +231,7 @@ The example using series would look like:
 This looks very much like the functional version: only the names have been changed.
 However, it compiles into efficient iterative code very much like the `dolist` version.
 
-Like pipes (see [section 9.3](B9780080571157500091.xhtml#s0015)), elements of a series are only evaluated when they are needed.
+Like pipes (see [section 9.3](chapter9.md#s0015)), elements of a series are only evaluated when they are needed.
 So we can write `(scan-range :from 0)` to indicate the infinite series of integers starting from 0, but if we only use, say, the first five elements of this series, then only the first five elements will be generated.
 
 The series facility offers a convenient and efficient alternative to iterative loops and sequence functions.
@@ -562,7 +562,7 @@ Each keyword is quite simple:
 The `collect` keyword poses another challenge.
 How do you collect a list of expressions presented one at a time?
 The answer is to view the expressions as a queue, one where we add items to the rear but never remove them from the front of the queue.
-Then we can use the queue functions defined in [section 10.5](B9780080571157500108.xhtml#s0025).
+Then we can use the queue functions defined in [section 10.5](chapter10.md#s0025).
 
 Unlike the other clauses, value accumulation clauses can communicate with each other.
 There can be, say, two `collect` and an append clause in the same loop, and they all build onto the same list.
@@ -700,7 +700,7 @@ There is one extra feature in loop's conditionals: the value of the test is stor
 The conditional clauses are a little tricky to implement, since they involve parsing other clauses.
 The idea is that `call-loop-fn` parses the THEN and ELSE parts, adding whatever is necessary to the body and to other parts of the loop structure.
 Then `add-body` is used to add labels and go statements that branch to the labels as needed.
-This is the same technique that is used to compile conditionals in [chapter 23](B9780080571157500236.xhtml); see the function `comp-if` on [page 787](B9780080571157500236.xhtml#p787).
+This is the same technique that is used to compile conditionals in [chapter 23](chapter23.md); see the function `comp-if` on [page 787](chapter23.md#p787).
 Here is the code:
 
 ```lisp
@@ -898,7 +898,7 @@ When this variable is non-nil, uninterned symbols are printed with a prefix `#`:
 This insures that the symbol will not be interned by a subsequent read.
 
 It is worth noting that Common Lisp automatically handles problems related to multiple evaluation of subforms in setf methods.
-See [page 884](B978008057115750025X.xhtml#p884) for an example.
+See [page 884](chapter25.md#p884) for an example.
 
 ### Avoid Overusing Macros
 
@@ -931,7 +931,7 @@ which would expand into:
     ((SETQ THAT (ASSOC ITEM A-LIST)) (PROCESS (CDR THAT)))))
 ```
 
-This was a convenient feature (compare it to the => feature of Scheme's cond, as discussed on [page 778](B9780080571157500224.xhtml#p778)), but it backfired often enough that I eventually gave up on my version of `if`.
+This was a convenient feature (compare it to the => feature of Scheme's cond, as discussed on [page 778](chapter22.md#p778)), but it backfired often enough that I eventually gave up on my version of `if`.
 Here's why.
 I would write code like this:
 
@@ -956,7 +956,7 @@ But in this case, violating referential transparency can lead to confusion.
 
 ### MAP-INTO
 
-The function `map-into` is used on [page 632](B9780080571157500182.xhtml#p632).
+The function `map-into` is used on [page 632](chapter18.md#p632).
 This function, added for the ANSI version of Common Lisp, is like `map`, except that instead of building a new sequence, the first argument is changed to hold the results.
 This section describes how to write a fairly efficient version of `map-into`, using techniques that are applicable to any sequence function.
 We'll start with a simple version:

--- a/docs/chapter25.md
+++ b/docs/chapter25.md
@@ -172,7 +172,7 @@ The following function is handy for this purpose:
 ```
 
 **Diagnosis:** Are you using `labels` and `flet` properly?
-Consider again the function `replace-?-vars`, which was defined in [section 11.3](B978008057115750011X.xhtml#s0025) to replace an anonymous logic variable with a unique new variable.
+Consider again the function `replace-?-vars`, which was defined in [section 11.3](chapter11.md#s0025) to replace an anonymous logic variable with a unique new variable.
 
 ```lisp
 (defun replace-?-vars (exp)
@@ -577,7 +577,7 @@ To avoid this problem, use `let*` whenever a variable's initial binding refers t
 
 ## 25.14 Problems with Macros
 
-In [section 3.2](B9780080571157500030.xhtml#s0015) we described a four-part approach to the design of macros:
+In [section 3.2](chapter3.md#s0015) we described a four-part approach to the design of macros:
 
 *   Decide if the macro is really necessary.
 
@@ -904,7 +904,7 @@ New functions should be introduced for any of the following reasons:
 
 In (2), it is interesting to consider what "too long" means.
 [Charniak et al.
-(1987)](B9780080571157500285.xhtml#bb0180) suggested that 20 lines is the limit.
+(1987)](bibliography.md#bb0180) suggested that 20 lines is the limit.
 But now that large bit-map displays have replaced 24-line terminals, function definitions have become longer.
 So perhaps one screenful is a better limit than 20 lines.
 The addition of `flet` and `labels` also contributes to longer function definitions.
@@ -1281,7 +1281,7 @@ It looks for the key in the a-list, and if the key is there, it modifies the cdr
 ----------------------
 
 <a id="fn25-1"></a><sup>[1](#tfn25-1)</sup>
-This misunderstanding has shown up even in published articles, such as [Baker 1991](B9780080571157500285.xhtml#bb0060).
+This misunderstanding has shown up even in published articles, such as [Baker 1991](bibliography.md#bb0060).
 
 <a id="fn25-2"></a><sup>[2](#tfn25-2)</sup>
 Scheme requires a list of keys in each clause.

--- a/docs/chapter3.md
+++ b/docs/chapter3.md
@@ -286,7 +286,7 @@ Here is a table of corresponding assignment forms in Lisp and Pascal:
 `setf` can be used to set a component of a structure as well as to set a variable.
 In languages like Pascal, the expressions that can appear on the left-hand side of an assignment statement are limited by the syntax of the language.
 In Lisp, the user can extend the expressions that are allowed in a `setf` form using the special forms `defsetf` or `define-setf-method`.
-These are introduced on [pages 514](B9780080571157500157.xhtml#p514) and [884](B978008057115750025X.xhtml#p884) respectively.
+These are introduced on [pages 514](chapter15.md#p514) and [884](chapter25.md#p884) respectively.
 
 There are also some built-in functions that modify places.
 For example, (`rplacd list nil`) has the same effect as (`setf` (`rest list`) `nil`), except that it returns `list` instead of `nil`.
@@ -734,9 +734,9 @@ First, to implement side effects in a branch of a two-branched conditional, one 
 If the conditional had only one branch, then `when` or `unless` should be used, since they allow an implicit `progn`.
 If there are more than two branches, then `cond` should be used.
 
-Second, `progn` is sometimes needed in macros that expand into more than one top-level form, as in the `defun*` macro on page 326, [section 10.3](B9780080571157500108.xhtml#s0020).
+Second, `progn` is sometimes needed in macros that expand into more than one top-level form, as in the `defun*` macro on page 326, [section 10.3](chapter10.md#s0020).
 Third, a progn is sometimes needed in an `unwind-protect`, an advanced macro.
-An example of this is the `with-resource` macro on [page 338](B9780080571157500108.xhtml#p338), [section 10.4](B9780080571157500108.xhtml#s0025).
+An example of this is the `with-resource` macro on [page 338](chapter10.md#p338), [section 10.4](chapter10.md#s0025).
 
 The forms `trace` and `untrace` are used to control debugging information about entry and exit to a function:
 
@@ -846,7 +846,7 @@ We can see what this macro expands into by using `macroexpand`, and see how it r
 NIL
 ```
 
-[Section 24.6](B9780080571157500248.xhtml) (page 853) describes a more complicated macro and some details on the pitfalls of writing complicated macros (page 855).
+[Section 24.6](chapter24.md) (page 853) describes a more complicated macro and some details on the pitfalls of writing complicated macros (page 855).
 
 ### Backquote Notation
 
@@ -867,7 +867,7 @@ The need to build up code (and noncode data) from components is so frequent that
 The backquote character ``"`"`` is similar to the quote character `"'"`.
 A backquote indicates that what follows is *mostly* a literal expression but may contain some components that are to be evaluated.
 Anything marked by a leading comma `","` is evaluated and inserted into the structure, and anything marked with a leading `",@"` must evaluate to a list that is spliced into the structure: each element of the list is inserted, without the top-level parentheses.
-The notation is covered in more detail in [section 23.5](B9780080571157500236.xhtml#s0030).
+The notation is covered in more detail in [section 23.5](chapter23.md#s0030).
 Here we use the combination of backquote and comma to rewrite `while`:
 
 ```lisp
@@ -1433,7 +1433,7 @@ The following table shows a number of more specialized data types that are not u
 
 In addition, there are even more specialized types, such as `short-float`, `compiled-function`, and `bit-vector`.
 It is also possible to construct more exact types, such as (`vector (integer 0 3) 100`), which represents a vector of 100 elements, each of which is an integer from 0 to 3, inclusive.
-[Section 10.1](B9780080571157500108.xhtml#s0010) gives more information on types and their use.
+[Section 10.1](chapter10.md#s0010) gives more information on types and their use.
 
 While almost every type has a predicate, it is also true that there are predicates that are not type recognizers but rather recognize some more general condition.
 For example, `oddp` is true only of odd integers, and `string-greaterp` is true if one string is alphabetically greater than another.
@@ -1765,7 +1765,7 @@ Calling the consistency checker is the fastest way to help isolate bugs in the d
 
 In addition, it is a good idea to keep a list of difficult test cases on hand.
 That way, when the program is changed, it will be easy to see if the change reintroduces a bug that had been previously removed.
-This is called *regression testing,* and [Waters (1991)](B9780080571157500285.xhtml#bb1350) presents an interesting tool for maintaining a suite of regression tests.
+This is called *regression testing,* and [Waters (1991)](bibliography.md#bb1350) presents an interesting tool for maintaining a suite of regression tests.
 But it is simple enough to maintain an informal test suite with a function that calls assert on a series of examples:
 
 ```lisp

--- a/docs/chapter4.md
+++ b/docs/chapter4.md
@@ -251,7 +251,7 @@ The unstated alternative is that otherwise, the problem is not solved.
 The function achieve is given as an argument a single goal.
 The function succeeds if that goal is already true in the current state (in which case we don't have to do anything) or if we can apply an appropriate operator.
 This is accomplished by first building the list of appropriate operators and then testing each in turn until one can be applied.
-`achieve` calls `find-all`, which we defined on [page 101](B9780080571157500030.xhtml#p101).
+`achieve` calls `find-all`, which we defined on [page 101](chapter3.md#p101).
 In this use, `find-all` returns a list of operators that match the current goal, according to the predicate `appropriate-p`.
 
 The function `appropriate-p` tests if an operator is appropriate for achieving a goal.
@@ -284,7 +284,7 @@ Clearly, it would be easier to describe the components.
 In this chapter we stick with the hyphenated atoms because it is simpler, and we do not need to describe the whole world.
 Subsequent chapters take knowledge representation more seriously.
 
-With this operator as a model, we can define other operators corresponding to Newell and Simon's quote on [page 109](B9780080571157500042.xhtml#p109).
+With this operator as a model, we can define other operators corresponding to Newell and Simon's quote on [page 109](chapter4.md#p109).
 There will be an operator for installing a battery, telling the repair shop the problem, and telephoning the shop.
 We can fill in the "and so on" by adding operators for looking up the shop's phone number and for giving the shop money:
 
@@ -981,7 +981,7 @@ The following code defines a set of operators for mazes in general, and for this
 ```
 
 Note the backquote notation, ( ' ).
-It is covered in [section 3.2](B9780080571157500030.xhtml#s0020), [page 67](B9780080571157500030.xhtml#p67).
+It is covered in [section 3.2](chapter3.md#s0020), [page 67](chapter3.md#p67).
 
 We can now use this list of operators to solve several problems with this maze.
 And we could easily create another maze by giving another list of connections.
@@ -1249,7 +1249,7 @@ The following example takes four steps when it could be done in two:
 
 How could we find shorter solutions?
 One way would be to do a full-fledged search: shorter solutions are tried first, temporarily abandoned when something else looks more promising, and then reconsidered later on.
-This approach is taken up in [chapter 6](B9780080571157500066.xhtml), using a general searching function.
+This approach is taken up in [chapter 6](chapter6.md), using a general searching function.
 A less drastic solution is to do a limited rearrangement of the order in which operators are searched: the ones with fewer unfulfilled preconditions are tried first.
 In particular, this means that operators with all preconditions filled would always be tried before other operators.
 To implement this approach, we change `achieve`:
@@ -1338,7 +1338,7 @@ This doesn't look too hard, so let's see how our GPS handles it:
 There is a "prerequisite clobbers sibling goal" problem regardless of which way we order the conjuncts!
 In other words, no combination of plans for the two individual goals can solve the conjunction of the two goals.
 This is a surprising fact, and the example has come to be known as "the Sussman anomaly."<a id="tfn04-4"></a><sup>[4](#fn04-4)</sup>
-We will return to this problem in [chapter 6](B9780080571157500066.xhtml).
+We will return to this problem in [chapter 6](chapter6.md).
 
 ## 4.15 Stage 5 Repeated: Analysis of Version 2
 
@@ -1402,7 +1402,7 @@ But in the taxi example, no amount of plan repair can get the money back once it
 
 There are two ways around this problem.
 The first approach is to examine all possible solutions, not just the first solution that achieves each subgoal.
-The language Prolog, to be discussed in [chapter 11](B978008057115750011X.xhtml), does just that.
+The language Prolog, to be discussed in [chapter 11](chapter11.md), does just that.
 The second approach is to have achieve and `achieve-all` keep track of a list of goals that must be *protected*.
 In the taxi example, we would trivially achieve the `have-money` goal and then try to achieve `son-at-school`, while protecting the goal `have-money`.
 An operator would only be appropriate if it didn't delete any protected goals.
@@ -1550,7 +1550,7 @@ The program should never undo a goal that has been achieved, but it should allow
 In this way, the program will solve the Sussman anomaly and similar problems.
 
 **Exercise  4.6 [d]** *The Lack of Descriptive Power Problem*.
-Read [chapters 5](B9780080571157500054.xhtml) and [6](B9780080571157500066.xhtml) to learn about pattern matching.
+Read [chapters 5](chapter5.md) and [6](chapter6.md) to learn about pattern matching.
 Write a version of GPS that uses the pattern matching tools, and thus allows variables in the operators.
 Apply it to the maze and blocks world domains.
 Your program will be more efficient if, like Chapman's Tweak program, you allow for the possibility of variables that remain unbound as long as possible.
@@ -1570,7 +1570,7 @@ The `"~?"` is the indirection operator: use the next argument as a format string
 ```
 
 **Answer 4.2** Here is one solution.
-The sophisticated Lisp programmer should also see the exercise on [page 680](B9780080571157500194.xhtml#p680).
+The sophisticated Lisp programmer should also see the exercise on [page 680](chapter19.md#p680).
 
 ```lisp
 (defun permutations (bag)
@@ -1593,14 +1593,14 @@ The sophisticated Lisp programmer should also see the exercise on [page 680](B97
 ----------------------
 
 <a id="fn04-1"></a><sup>[1](#tfn04-1)</sup>
-Strips is the Stanford Research Institute Problem Solver, designed by [Richard Fikes and Nils Nilsson (1971)](B9780080571157500285.xhtml#bb0405).
+Strips is the Stanford Research Institute Problem Solver, designed by [Richard Fikes and Nils Nilsson (1971)](bibliography.md#bb0405).
 
 <a id="fn04-2"></a><sup>[2](#tfn04-2)</sup>
 Gerald Sussman, in his book *A Computer Model of Skill Acquisition,* uses the term "prerequisite clobbers brother goal" or PCBG.
 I prefer to be gender neutral, even at the risk of being labeled a historical revisionist.
 
 <a id="fn04-3"></a><sup>[3](#tfn04-3)</sup>
-Originally posed by [Saul Amarel (1968)](B9780080571157500285.xhtml#bb0045).
+Originally posed by [Saul Amarel (1968)](bibliography.md#bb0045).
 
 <a id="fn04-4"></a><sup>[4](#tfn04-4)</sup>
 A footnote in Waldinger 1977 says, "This problem was proposed by Allen Brown.

--- a/docs/chapter5.md
+++ b/docs/chapter5.md
@@ -325,7 +325,7 @@ Notice the distinction between `NIL` and `((T . T))`.
 The latter means that the match succeeded, but there were no bindings to return.
 Also, remember that `(?X 2 + 2)` means the same as `(?X . (2 + 2))`.
 
-A more powerful implementation of `pat-match` is given in chapter 6.
+A more powerful implementation of `pat-match` is given in [chapter 6](chapter6.md).
 Yet another implementation is given in section 10.4.
 It is more efficient but more cumbersome to use.
 

--- a/docs/chapter6.md
+++ b/docs/chapter6.md
@@ -5,7 +5,7 @@
 
 > -Thomas Carlyle (1795-1881)
 
-In [chapters 4](B9780080571157500042.xhtml) and [5](B9780080571157500054.xhtml) we were concerned with building two particular programs, GPS and ELIZA. In this chapter, we will reexamine those two programs to discover some common patterns.
+In [chapters 4](chapter4.md) and [5](chapter5.md) we were concerned with building two particular programs, GPS and ELIZA. In this chapter, we will reexamine those two programs to discover some common patterns.
 Those patterns will be abstracted out to form reusable software tools that will prove helpful in subsequent chapters.
 
 ## 6.1 An Interactive Interpreter Tool
@@ -196,7 +196,7 @@ It has to be listed as a segment pattern rather than a single pattern because it
 ```
 
 When the description of a problem gets this complicated, it is a good idea to attempt a more formal specification.
-The following table describes a grammar of patterns, using the same grammar rule format described in [chapter 2](B9780080571157500029.xhtml).
+The following table describes a grammar of patterns, using the same grammar rule format described in [chapter 2](chapter2.md).
 
 | []()            |                         |                                                   |
 |-----------------|-------------------------|---------------------------------------------------|
@@ -300,7 +300,7 @@ Then programmers who want to extend the matcher just add entries to the table, a
 This style of programming, where pattern/action pairs are stored in a table, is called *data*-*driven programming*.
 It is a very flexible style that is appropriate for writing extensible systems.
 
-There are many ways to implement tables in Common Lisp, as discussed in [section 3.6](B9780080571157500030.xhtml#s0080), [page 73](B9780080571157500030.xhtml#p73).
+There are many ways to implement tables in Common Lisp, as discussed in [section 3.6](chapter3.md#s0080), [page 73](chapter3.md#p73).
 In this case, the keys to the table will be symbols  (like `?*`), and it is fine if the representation of the table is distributed across memory.
 Thus, property lists are an appropriate choice.
 We will have two tables, represented by the `segment-match` property and the `single-match` property of symbols like `?*`.
@@ -960,7 +960,7 @@ The cities are shown on the map in [figure 6.1](#fig-06-01), which has connectio
 This map was drawn with the help of `air-distance`, a function that returns the distance in kilometers between two cities "as the crow flies."
 It will be defined later.
 Two other useful functions are `neighbors`, which finds all the cities within 1000 kilometers, and `city`, which maps from a name to a city.
-The former uses `find-all-if`, which was defined on [page 101](B9780080571157500030.xhtml#p101) as a synonym for `remove-if-not`.
+The former uses `find-all-if`, which was defined on [page 101](chapter3.md#p101) as a synonym for `remove-if-not`.
 
 | <a id="fig-06-01"></a>[]() |
 |---|
@@ -1271,7 +1271,7 @@ Of course, iterative deepening does waste some time because at each increasing d
 But suppose that the average state has ten successors.
 That means that increasing the depth by one results in ten times more search, so only 10% of the time is wasted on repeated work.
 So iterative deepening uses only slightly more time and much less space.
-We will see it again in [chapters 11](B978008057115750011X.xhtml) and [18](B9780080571157500182.xhtml).
+We will see it again in [chapters 11](chapter11.md) and [18](chapter18.md).
 
 ### Searching Graphs
 
@@ -1498,7 +1498,7 @@ They could be arranged in a graph and searched just as we searched for a route b
 | **Figure 6.5: The Blocks World as a Graph** |
 
 The function `search-gps` does just that.
-Like the gps function on [page 135](B9780080571157500042.xhtml#p135), it computes a final state and then picks out the actions that lead to that state.
+Like the gps function on [page 135](chapter4.md#p135), it computes a final state and then picks out the actions that lead to that state.
 But it computes the state with a beam search.
 The goal predicate tests if the current state satisfies every condition in the goal, the successor function finds all applicable operators and applies them, and the cost function simply sums the number of actions taken so far, plus the number of conditions that are not yet satisfied:
 
@@ -1567,13 +1567,13 @@ This is left as an exercise.
 
 Pattern matching is one of the most important tools for AI.
 As such, it is covered in most textbooks on Lisp.
-Good treatments include Abelson and Sussman (1984), [Wilensky (1986)](B9780080571157500285.xhtml#bb1390), [Winston and Horn (1988)](B9780080571157500285.xhtml#bb1410), and [Kreutzer and McKenzie (1990)](B9780080571157500285.xhtml#bb0680).
-An overview is presented in the "pattern-matching" entry in *Encyclopedia of AI* ([Shapiro 1990](B9780080571157500285.xhtml#bb1085)).
+Good treatments include Abelson and Sussman (1984), [Wilensky (1986)](bibliography.md#bb1390), [Winston and Horn (1988)](bibliography.md#bb1410), and [Kreutzer and McKenzie (1990)](bibliography.md#bb0680).
+An overview is presented in the "pattern-matching" entry in *Encyclopedia of AI* ([Shapiro 1990](bibliography.md#bb1085)).
 
 Nilsson's *Problem*-*Solving Methods in Artificial Intelligence* (1971) was an early text-book that emphasized search as the most important defining characteristic of AI.
 More recent texts give less importance to search; Winston's *Artificial Intelligence* (1984) gives a balanced overview, and his *Lisp* (1988) provides implementations of some of the algorithms.
 They are at a lower level of abstraction than the ones in this chapter.
-Iterative deepening was first presented by [Korf (1985)](B9780080571157500285.xhtml#bb0640), and iterative broadening by [Ginsberg and Harvey (1990)](B9780080571157500285.xhtml#bb0470).
+Iterative deepening was first presented by [Korf (1985)](bibliography.md#bb0640), and iterative broadening by [Ginsberg and Harvey (1990)](bibliography.md#bb0470).
 
 ## 6.7 Exercises
 
@@ -1754,7 +1754,7 @@ The built-in constant `most-positive-fixnum` is a large integer, the largest tha
 Its value depends on the implementation, but in most Lisps it is over 16 million.
 
 <a id="fn06-4"></a><sup>[4](#tfn06-4)</sup>
-In [chapter 8](B978008057115750008X.xhtml) we will see an example where the fog did lift: symbolic integration was once handled as a problem in search, but new mathematical results now make it possible to solve the same class of integration problems without search.
+In [chapter 8](chapter8.md) we will see an example where the fog did lift: symbolic integration was once handled as a problem in search, but new mathematical results now make it possible to solve the same class of integration problems without search.
 
 <a id="fn06-5"></a><sup>[5](#tfn06-5)</sup>
 The astute reader will recognize that this graph is not a tree.

--- a/docs/chapter7.md
+++ b/docs/chapter7.md
@@ -3,7 +3,7 @@
 
 > *[This] is an example par excellence* of the power of using meaning to solve linguistic problems.
 >
-> -[Marvin Minsky (1968)](B9780080571157500285.xhtml#bb0845)
+> -[Marvin Minsky (1968)](bibliography.md#bb0845)
 >
 > MIT computer scientist
 
@@ -32,7 +32,7 @@ The description of STUDENT is:
 2.  Break each phrase into a pair of phrases on either side of the = sign.
 
 3.  Break these phrases down further into sums and products, and so on, until finally we bottom out with numbers and variables.
-(By "variable" here, I mean "mathematical variable," which is distinct from the idea of a "pattern-matching variable" as used in `pat-match` in [chapter 6](B9780080571157500066.xhtml)).
+(By "variable" here, I mean "mathematical variable," which is distinct from the idea of a "pattern-matching variable" as used in `pat-match` in [chapter 6](chapter6.md)).
 
 4.  Translate each English phrase into a mathematical expression.
 We use the idea of a rule-based translator as developed for ELIZA.
@@ -629,11 +629,11 @@ That is why the STUDENT approach was abandoned as a research topic.
 
 Bobrow's Ph.D.
 thesis contains a complete description of STUDENT.
-It is reprinted in [Minsky 1968](B9780080571157500285.xhtml#bb0845).
+It is reprinted in [Minsky 1968](bibliography.md#bb0845).
 Since then, there have been several systems that address the same task, with increased sophistication in both their mathematical and linguistic ability.
-[Wong (1981)](B9780080571157500285.xhtml#bb1420) describes a system that uses its understanding of the problem to get a better linguistic analysis.
+[Wong (1981)](bibliography.md#bb1420) describes a system that uses its understanding of the problem to get a better linguistic analysis.
 [Sterling et al.
-(1982)](B9780080571157500285.xhtml#bb1195) present a much more powerful equation solver, but it does not accept natural language input.
+(1982)](bibliography.md#bb1195) present a much more powerful equation solver, but it does not accept natural language input.
 Certainly Bobrow's language analysis techniques were not very sophisticated by today's measures.
 But that was largely the point: if you know that the language is describing an algebraic problem of a certain type, then you don't need to know very much linguistics to get the right answer most of the time.
 

--- a/docs/chapter8.md
+++ b/docs/chapter8.md
@@ -67,7 +67,7 @@ The first is fully parenthesized infix, the second makes use of operator precede
 The fourth requires a lexical analyzer to break Lisp symbols into pieces.
 
 Suppose we only wanted to handle the fully parenthesized case.
-To write `infix->prefix`, one might first look at `prefix->infix` (on [page 228](B9780080571157500078.xhtml#p228)) trying to adapt it to our new purposes.
+To write `infix->prefix`, one might first look at `prefix->infix` (on [page 228](chapter7.md#p228)) trying to adapt it to our new purposes.
 In doing so, the careful reader might discover a surprise: `infix->prefix` and `prefix->infix` are in fact the exact same function!
 Both leave atoms unchanged, and both transform three-element lists by swapping the `exp-op` and `exp-lhs`.
 Both apply themselves recursively to the (possibly rearranged) input list.
@@ -141,7 +141,7 @@ Because we are doing mathematics in this chapter, we adopt the mathematical conv
 ## 8.2 Simplification Rules
 
 Now we are ready to define the simplification rules.
-We use the definition of the data types rule and exp ([page 221](B9780080571157500078.xhtml#p221)) and `prefix->infix` ([page 228](B9780080571157500078.xhtml#p228)) from STUDENT.
+We use the definition of the data types rule and exp ([page 221](chapter7.md#p221)) and `prefix->infix` ([page 228](chapter7.md#p228)) from STUDENT.
 They are repeated here:
 
 ```lisp
@@ -166,7 +166,7 @@ They are repeated here:
   (and (exp-p x) (= (length (exp-args x)) 2)))
 ```
 
-We also use `rule-based-translator` ([page 188](B9780080571157500066.xhtml#p188)) once again, this time on a list of simplification rules.
+We also use `rule-based-translator` ([page 188](chapter6.md#p188)) once again, this time on a list of simplification rules.
 A reasonable list of simplification rules is shown below.
 This list covers the four arithmetic operators, addition, subtraction, multiplication, and division, as well as exponentiation (raising to a power), denoted by the symbol "^"
 
@@ -565,7 +565,7 @@ SIMPLIFIER > (3 * x + y + x + 4 * x)
 ```
 
 We would want `(3 * x)` to sort to the same place as `x` and `(4 * x )` so that they could all be combined to `(8 * x)`.
-In [chapter 15](B9780080571157500157.xhtml), we develop a new version of the program that handles this problem.
+In [chapter 15](chapter15.md), we develop a new version of the program that handles this problem.
 
 ## 8.6 Integration
 
@@ -904,21 +904,21 @@ A brief history is given in the introduction to this chapter.
 An interesting point is that the history of Lisp and of symbolic algebraic manipulation are deeply intertwined.
 It is not too gross an exaggeration to say that Lisp was invented by John McCarthy to express the symbolic differentiation algorithm.
 And the development of the first high-quality Lisp system, MacLisp, was driven largely by the needs of MACSYMA, one of the first large Lisp systems.
-See [McCarthy 1958](B9780080571157500285.xhtml#bb0790) for early Lisp history and the differentiation algorithm, and [Martin and Fateman 1971](B9780080571157500285.xhtml#bb0775) and [Moses (1975)](B9780080571157500285.xhtml#bb0875) for more details on MACSYMA.
-A comprehensive book on computer algebra systems is [Davenport 1988](B9780080571157500285.xhtml#bb0270).
+See [McCarthy 1958](bibliography.md#bb0790) for early Lisp history and the differentiation algorithm, and [Martin and Fateman 1971](bibliography.md#bb0775) and [Moses (1975)](bibliography.md#bb0875) for more details on MACSYMA.
+A comprehensive book on computer algebra systems is [Davenport 1988](bibliography.md#bb0270).
 It covers the MACSYMA and REDUCE systems as well as the algorithms behind those systems.
 
-Because symbolic differentiation is historically important, it is presented in a number of text books, from the original Lisp 1.5 Primer ([Weissman 1967](B9780080571157500285.xhtml#bb1370)) and Allen's influential [*Anatomy of Lisp* (1978)](B9780080571157500285.xhtml#bb0040) to recent texts like [Brooks 1985](B9780080571157500285.xhtml#bb0135), [Hennessey 1989](B9780080571157500285.xhtml#bb0530), and [Tanimoto 1990](B9780080571157500285.xhtml#bb1220).
+Because symbolic differentiation is historically important, it is presented in a number of text books, from the original Lisp 1.5 Primer ([Weissman 1967](bibliography.md#bb1370)) and Allen's influential [*Anatomy of Lisp* (1978)](bibliography.md#bb0040) to recent texts like [Brooks 1985](bibliography.md#bb0135), [Hennessey 1989](bibliography.md#bb0530), and [Tanimoto 1990](bibliography.md#bb1220).
 Many of these books use rules or data-driven programming, but each treats differentiation as the main task, with simplification as a separate problem.
 None of them use the approach taken here, where differentiation is just another kind of simplification.
 
-The symbolic integration programs SAINT and SIN are covered in [Slagle 1963](B9780080571157500285.xhtml#bb1115) and [Moses 1967](B9780080571157500285.xhtml#bb0870), respectively.
-The mathematical solution to the problem of integration in closed term is addressed in [Risch 1969](B9780080571157500285.xhtml#bb0985), but be warned; this paper is not for the mathematically naive, and it has no hints on programming the algorithm.
+The symbolic integration programs SAINT and SIN are covered in [Slagle 1963](bibliography.md#bb1115) and [Moses 1967](bibliography.md#bb0870), respectively.
+The mathematical solution to the problem of integration in closed term is addressed in [Risch 1969](bibliography.md#bb0985), but be warned; this paper is not for the mathematically naive, and it has no hints on programming the algorithm.
 A better reference is [Davenport et al.
-1988](B9780080571157500285.xhtml#bb0270).
+1988](bibliography.md#bb0270).
 
-In this book, techniques for improving the efficiency of algebraic manipulation are covered in [sections 9.6](B9780080571157500091.xhtml#s0035) and [10.4](B9780080571157500108.xhtml#s0025).
-[Chapter 15](B9780080571157500157.xhtml) presents a reimplementation that does not use pattern-matching, and is closer to the techniques used in MACSYMA.
+In this book, techniques for improving the efficiency of algebraic manipulation are covered in [sections 9.6](chapter9.md#s0035) and [10.4](chapter10.md#s0025).
+[Chapter 15](chapter15.md) presents a reimplementation that does not use pattern-matching, and is closer to the techniques used in MACSYMA.
 
 ## 8.8 Exercises
 
@@ -955,7 +955,7 @@ One simple control rule is to allow integration by parts only at the top level, 
 Implement this approach.
 
 **Exercise 8.6 [d]** A more complicated approach is to try to decide which ways of breaking up the original expression are promising and which are not.
-Derive some heuristics for making this division, and reimplement `integrate` to include a search component, using the search tools of [chapter 6](B9780080571157500066.xhtml).
+Derive some heuristics for making this division, and reimplement `integrate` to include a search component, using the search tools of [chapter 6](chapter6.md).
 
 Look in a calculus textbook to see how &int;sin<sup>2</sup>*(x)dx* is evaluated by two integrations by parts and a division.
 Implement this technique as well.

--- a/docs/chapter8.md
+++ b/docs/chapter8.md
@@ -861,7 +861,7 @@ We could go back and edit `simplify-exp` to change the convention, but instead I
           (integrate (exp-lhs exp) (exp-rhs exp))))
 ```
 
-Here are some examples, taken from [chapters 8](#c0040) and [9](B9780080571157500091.xhtml) of *Calculus* ([Loomis 1974](B9780080571157500285.xhtml#bb0750)):
+Here are some examples, taken from chapters 8 and 9 of *Calculus* ([Loomis 1974](bibliography.md#bb0750)):
 
 ```lisp
 SIMPLIFIER > (Int x * sin(x ^ 2) d x)

--- a/docs/chapter9.md
+++ b/docs/chapter9.md
@@ -42,7 +42,7 @@ Common Lisp implementations have compilers, so this is no longer a problem.
 While Lisp is (primarily) no longer an interpreted language, it is still an *interactive* language, so it retains its flexibility.
 
 *   Lisp has often been used to write interpreters for embedded languages, thereby compounding the problem.
-Consider this quote from [Cooper and Wogrin's (1988)](B9780080571157500285.xhtml#bb0260) book on the rule-based programming language OPS5:
+Consider this quote from [Cooper and Wogrin's (1988)](bibliography.md#bb0260) book on the rule-based programming language OPS5:
 
 > The efficiency of implementations that compile rules into executable code compares favorably to that of programs written in most sequential languages such as FORTRAN or Pascal Implementations that compile rules into data structures to be interpreted, as do many Lisp-based ones, could be noticeably slower.
 
@@ -53,7 +53,7 @@ This book is the first that concentrates on using Lisp as both the implementatio
 
 *   Lisp encourages a style with lots of function calls, particularly recursive calls.
 In some older systems, function calls were expensive.
-But it is now understood that a function call can be compiled into a simple branch instruction, and that many recursive calls can be made no more expensive than an equivalent iterative loop (see [chapter 22](B9780080571157500224.xhtml)).
+But it is now understood that a function call can be compiled into a simple branch instruction, and that many recursive calls can be made no more expensive than an equivalent iterative loop (see [chapter 22](chapter22.md)).
 It is also possible to instruct a Common Lisp compiler to compile certain functions inline, so there is no calling overhead at all.
 On the other hand, many Lisp systems require two fetches instead of one to find the code for a function, and thus will be slower.
 This extra level of indirection is the price paid for the freedom of being able to redefine functions without reloading the whole program.
@@ -64,10 +64,10 @@ For example, we can write `(+ x y)` without bothering to declare if `x` and `y` 
 This is very convenient, but it means that type checks must be made at run time, so the generic  +  will be slower than, say, a 16-bit integer addition with no check for overflow.
 If efficiency is important, Common Lisp allows the programmer to include declarations that can eliminate run-time checks.
 In fact, once the proper declarations are added, Lisp can be as fast or faster than conventional languages.
-[Fateman (1973)](B9780080571157500285.xhtml#bb0375) compared the FORTRAN cube root routine on the PDP-10 to a MacLisp transliteration.
+[Fateman (1973)](bibliography.md#bb0375) compared the FORTRAN cube root routine on the PDP-10 to a MacLisp transliteration.
 The MacLisp version produced almost identical numerical code, but was 18% faster overall, due to a superior function-calling sequence.<a id="tfn09-1"></a><sup>[1](#fn09-1)</sup>
 The epigraph at the beginning of this chapter is from this article.
-[Berlin and Weise (1990)](B9780080571157500285.xhtml#bb0085) show that with a special compilation technique called *partial evaluation*, speeds 7 to 90 times faster than conventionally compiled code can be achieved.
+[Berlin and Weise (1990)](bibliography.md#bb0085) show that with a special compilation technique called *partial evaluation*, speeds 7 to 90 times faster than conventionally compiled code can be achieved.
 Of course, partial evaluation could be used in any language, but it is very easy to do in Lisp.
 The fact remains that Lisp objects must somehow represent their type, and even with declarations, not all of this overhead can be eliminated.
 Most Lisp implementations optimize access to lists and fixnums but pay the price for the other, less commonly used data types.
@@ -91,7 +91,7 @@ Some recent compilers support this option, but it is not widely available yet.
 In general, the problem is not that an efficient encoding is impossible but that it is difficult to arrive at that efficient encoding.
 In a language like C, the experienced programmer has a pretty good idea how each statement will compile into assembly language instructions.
 But in Lisp, very similar statements can compile into widely different assembly-level instructions, depending on subtle interactions between the declarations given and the capabilities of the compiler.
-[Page 318](B9780080571157500108.xhtml#p318) gives an example where adding a declaration speeds up a trivial function by 40 times.
+[Page 318](chapter10.md#p318) gives an example where adding a declaration speeds up a trivial function by 40 times.
 Nonexperts do not understand when such declarations are necessary and are frustrated by the seeming inconsistencies.
 With experience, the expert Lisp programmer eventually develops a good "efficiency model," and the need for such declarations becomes obvious.
 Recent compilers such as CMU's Python provide feedback that eases this learning process.
@@ -123,7 +123,7 @@ It then addresses the important problem of *instrumentation*.
 The chapter concludes with a case study of the simplify program.
 The techniques outlined here result in a 130-fold speed-up in this program.
 
-[Chapter 10](B9780080571157500108.xhtml) concentrates on lower-level "tricks" for improving efficiency further.
+[Chapter 10](chapter10.md) concentrates on lower-level "tricks" for improving efficiency further.
 
 ## 9.1 Caching Results of Previous Computations: Memoization
 
@@ -330,7 +330,7 @@ The notation *O*(*f*(*n*)) is used to describe the complexity.
 For example, the memoized version `fib` is an *O*(*n*) algorithm because the computation time is bounded by some constant times *n*, for any value of *n*.
 The unmemoized version, it turns out, is *O*(1.7*<sup>n</sup>*), meaning computing `fib` of `n+1` can take up to 1.7 times as long as `fib` of *n*.
 In simpler terms, the memoized version has *linear* complexity, while the unmemoized version has *exponential* complexity.
-[Exercise 9.4](B9780080571157500091.xhtml#p4655) ([page 308](B9780080571157500091.xhtml#p308)) describes where the 1.7 comes from, and gives a tighter bound on the complexity.
+[Exercise 9.4](chapter9.md#p4655) ([page 308](chapter9.md#p308)) describes where the 1.7 comes from, and gives a tighter bound on the complexity.
 
 The version of `memo` presented above is inflexible in several ways.
 First, it only works for functions of one argument.
@@ -379,7 +379,7 @@ Note that if the key is a list of arguments, then you will have to use `equal` h
 
 ## 9.2 Compiling One Language into Another
 
-In [chapter 2](B9780080571157500029.xhtml) we defined a new language-the language of grammar rules-which was processed by an interpreter designed especially for that language.
+In [chapter 2](chapter2.md) we defined a new language-the language of grammar rules-which was processed by an interpreter designed especially for that language.
 An *interpreter* is a program that looks at some data structure representing a "program" or sequence of rules of some sort and interprets or evaluates those rules.
 This is in contrast to a *compiler*, which translates some set of rules in one language into a program in another language.
 
@@ -389,7 +389,7 @@ Interpreting these rules is straightforward, but the process is somewhat ineffic
 A compiler for this rule-language would take each rule and translate it into a function.
 These functions could then call each other with no need to search through the `*grammar*`.
 We implement this approach with the function `compile-rule`.
-It makes use of the auxiliary functions `one-of` and `rule-lhs` and `rule-rhs` from [page 40](B9780080571157500029.xhtml#p40), repeated here:
+It makes use of the auxiliary functions `one-of` and `rule-lhs` and `rule-rhs` from [page 40](chapter2.md#p40), repeated here:
 
 ```lisp
 (defun rule-lhs (rule)
@@ -486,7 +486,7 @@ We can see the Lisp code generated by `compile-rule` in two ways: by passing it 
 ```
 
 or by macroexpanding a `defrule` expression.
-The compiler was designed to produce the same code we were writing in our first approach to the generation problem (see [page 35](B9780080571157500029.xhtml#p35)).
+The compiler was designed to produce the same code we were writing in our first approach to the generation problem (see [page 35](chapter2.md#p35)).
 
 ```lisp
 > (macroexpand '(defrule Adj* -> () Adj (Adj Adj*)))
@@ -549,7 +549,7 @@ The grammar writer has to make sure he or she is not using the name of an existi
 Even worse, if more than one grammar is being developed at the same time, they cannot have any functions in common.
 If they do, the user will have to recompile with every switch from one grammar to another.
 This may make it difficult to compare grammars.
-The best away around this problem is to use the Common Lisp idea of *packages*, but for small exercises name clashes can be avoided easily enough, so we will not explore packages until [section 24.1](B9780080571157500248.xhtml#s0010).
+The best away around this problem is to use the Common Lisp idea of *packages*, but for small exercises name clashes can be avoided easily enough, so we will not explore packages until [section 24.1](chapter24.md#s0010).
 
 The major advantage of a compiler is speed of execution, when that makes a difference.
 For identical grammars running in one particular implementation of Common Lisp on one machine, our interpreter generates about 75 sentences per second, while the compiled approach turns out about 200.
@@ -604,7 +604,7 @@ With another compiler that didn't know about such optimizations, I would have to
 
 ## 9.3 Delaying Computation
 
-Back on [page 45](B9780080571157500029.xhtml#p45), we saw a program to generate all strings derivable from a grammar.
+Back on [page 45](chapter2.md#p45), we saw a program to generate all strings derivable from a grammar.
 One drawback of this program was that some grammars produce an infinite number of strings, so the program would not terminate on those grammars.
 
 It turns out that we often want to deal with infinite sets.
@@ -667,7 +667,7 @@ An infinite set will be considered a special case of what we will call a *pipe*:
 Pipes have also been called delayed lists, generated lists, and (most commonly) streams.
 We will use the term *pipe* because *stream* already has a meaning in Common Lisp.
 The book *Artificial Intelligence Programming* ([Charniak et al.
-1987](B9780080571157500285.xhtml#bb0180)) also calls these structures pipes, reserving streams for delayed structures that do not cache computed results.
+1987](bibliography.md#bb0180)) also calls these structures pipes, reserving streams for delayed structures that do not cache computed results.
 
 To distinguish pipes from lists, we will use the accessors `head` and `tail` instead of `first` and `rest`.
 We will also use `empty-pipe` instead of `nil, make-pipe` instead of `cons`, and `pipe-elt` instead of `elt`.
@@ -854,7 +854,7 @@ First we're going to need some more utility functions:
 
 Now we can rewrite `generate-all` and `combine-all` to use pipes instead of lists.
 
-Everything else is the same as on [page 45](B9780080571157500029.xhtml#p45).
+Everything else is the same as on [page 45](chapter2.md#p45).
 
 ```lisp
 (defun generate-all (phrase)
@@ -879,7 +879,7 @@ Everything else is the same as on [page 45](B9780080571157500029.xhtml#p45).
    ypipe))
 ```
 
-With these definitions, here's the pipe of all sentences from `*grammar2*` (from [page 43](B9780080571157500029.xhtml#p43)):
+With these definitions, here's the pipe of all sentences from `*grammar2*` (from [page 43](chapter2.md#p43)):
 
 ```lisp
 > (setf ss (generate-all 'sentence)) =>
@@ -910,7 +910,7 @@ For example, if the expansion for `Adj*` had been `(Adj* -> (Adj* Adj) ())` inst
 
 We have used delays and pipes for two main purposes: to put off until later computations that may not be needed at all, and to have an explicit representation of large or infinite sets.
 It should be mentioned that the language Prolog has a different solution to the first problem (but not the second).
-As we shall see in [chapter 11](B978008057115750011X.xhtml), Prolog generates solutions one at a time, automatically keeping track of possible backtrack points.
+As we shall see in [chapter 11](chapter11.md), Prolog generates solutions one at a time, automatically keeping track of possible backtrack points.
 Where pipes allow us to represent an infinite number of alternatives in the data, Prolog allows us to represent those alternatives in the program itself.
 
 **Exercise 9.1 [h]** When given a function `f` and a pipe `p`, `mappend-pipe` returns a new pipe that will eventually enumerate all of `(f (first p))`, then all of `(f (second p))`, and so on.
@@ -931,7 +931,7 @@ Picking the right data structure and algorithm is as important in Lisp as it is 
 Even though Lisp offers a wide variety of data structures, it is often worthwhile to spend some effort on building just the right data structure for frequently used data.
 For example, Lisp's hash tables are very general and thus can be inefficient.
 You may want to build your own hash tables if, for example, you never need to delete elements, thus making open hashing an attractive possibility.
-We will see an example of efficient indexing in [section 9.6](#s0035) ([page 297](B9780080571157500091.xhtml#p297)).
+We will see an example of efficient indexing in [section 9.6](#s0035) ([page 297](chapter9.md#p297)).
 
 ## 9.5 Instrumentation: Deciding What to Optimize
 
@@ -1133,7 +1133,7 @@ With an `inline` function, the body of the function is compiled in line at the p
 Thus, there is no overhead for setting up the argument list and branching to the definition.
 An `inline` declaration can appear anywhere any other declaration can appear.
 In this case, the function `proclaim` is used to register a global declaration.
-Inline declarations are discussed in more depth on [page 317](B9780080571157500108.xhtml#p317).
+Inline declarations are discussed in more depth on [page 317](chapter10.md#p317).
 
 ```lisp
 (proclaim '(inline profile-enter profile-exit inc-profile-time))
@@ -1214,9 +1214,9 @@ But if an error occurs during the evaluation of the first argument and computati
 
 ## 9.6 A Case Study in Efficiency: The SIMPLIFY Program
 
-Suppose we wanted to speed up the `simplify` program of [chapter 8](B978008057115750008X.xhtml).
+Suppose we wanted to speed up the `simplify` program of [chapter 8](chapter8.md).
 This section shows how a combination of general techniques-memoizing, indexing, and compiling-can be used to speed up the program by a factor of 130.
-[Chapter 15](B9780080571157500157.xhtml) will show another approach: replace the algorithm with an entirely different one.
+[Chapter 15](chapter15.md) will show another approach: replace the algorithm with an entirely different one.
 
 The first step to a faster program is defining a *benchmark*, a test suite representing a typical work load.
 The following is a short list of test problems (and their answers) that are typical of the `simplify` task.
@@ -1746,18 +1746,18 @@ The idea of memoization was introduced by Donald Michie 1968.
 He proposed using a list of values rather than a hash table, so the savings was not as great.
 In mathematics, the field of dynamic programming is really just the study of how to compute values in the proper order so that partial results will already be cached away when needed.
 
-A large part of academic computer science covers compilation; [Aho and Ullman 1972](B9780080571157500285.xhtml#bb0015) is just one example.
+A large part of academic computer science covers compilation; [Aho and Ullman 1972](bibliography.md#bb0015) is just one example.
 The technique of compiling embedded languages (such as the language of pattern-matching rules) is one that has achieved much more attention in the Lisp community than in the rest of computer science.
-See [Emanuelson and Haraldsson 1980](B9780080571157500285.xhtml#bb0365), for an example.
+See [Emanuelson and Haraldsson 1980](bibliography.md#bb0365), for an example.
 
-Choosing the right data structure, indexing it properly, and defining algorithms to operate on it is another important branch of computer science; [Sedgewick 1988](B9780080571157500285.xhtml#bb1065) is one example, but there are many worthy texts.
+Choosing the right data structure, indexing it properly, and defining algorithms to operate on it is another important branch of computer science; [Sedgewick 1988](bibliography.md#bb1065) is one example, but there are many worthy texts.
 
 Delaying computation by packaging it up in a `lambda` expression is an idea that goes back to Algol's use of *thunks*-a mechanism to implement call-by-name parameters, essentially by passing functions of no arguments.
 The name *thunk* comes from the fact that these functions can be compiled: the system does not have to think about them at run time, because the compiler has already thunk about them.
-Peter [Ingerman 1961](B9780080571157500285.xhtml#bb0570) describes thunks in detail.
-[Abelson and Sussman 1985](B9780080571157500285.xhtml#bb0010) cover delays nicely.
+Peter [Ingerman 1961](bibliography.md#bb0570) describes thunks in detail.
+[Abelson and Sussman 1985](bibliography.md#bb0010) cover delays nicely.
 The idea of eliminating unneeded computation is so attractive that entire languages have built around the concept of *lazy evaluation*-don't evaluate an expression until its value is needed.
-See [Hughes 1985](B9780080571157500285.xhtml#bb0565) or [Field and Harrison 1988](B9780080571157500285.xhtml#bb0400).
+See [Hughes 1985](bibliography.md#bb0565) or [Field and Harrison 1988](bibliography.md#bb0400).
 
 ## 9.8 Exercises
 
@@ -1816,7 +1816,7 @@ The function should take as argument a function representing a strategy for play
 Read the definition of the function `random` and describe how a player could cheat.
 Then describe a countermeasure.
 
-**Exercise 9.10 [m]** On [page 292](B9780080571157500091.xhtml#p292) we saw the use of the read-time conditionals, `#+` and `#-`, where `#+` is the read-time equivalent of when, and `#-` is the read-time equivalent of unless.
+**Exercise 9.10 [m]** On [page 292](chapter9.md#p292) we saw the use of the read-time conditionals, `#+` and `#-`, where `#+` is the read-time equivalent of when, and `#-` is the read-time equivalent of unless.
 Unfortunately, there is no read-time equivalent of case.
 Implement one.
 


### PR DESCRIPTION
Meaning: links should go to (current, useful, clear)  `chapter1.md`, not (from the source ebook) `B9780080571157500017.xhtml`.
This isn't meant to fix references to e.g. sections / subchapters, pages, exercises, figures, or diagrams.
Those will require additional markup, which is a source of incompatibility between markdown parsers.
(I think linking to sections / subchapters is probably better than page numbers, too.)

Resolves #161. 