### PR TITLE
fixed typo in keyword argument

### DIFF
--- a/docs/chapter3.md
+++ b/docs/chapter3.md
@@ -573,7 +573,7 @@ Second, many of the functions accept keywords that allow the user to vary the te
 
 > (remove 1 '(1 2 3 2 1 0 -1) :test #'<) => (1 1 0 -1)
 
-> (remove 1 '(1 2 3 2 1 0 -1) : start 4) => (1 2 3 2 0 -1)
+> (remove 1 '(1 2 3 2 1 0 -1) :start 4) => (1 2 3 2 0 -1)
 ```
 
 Third, some have corresponding functions ending in `-if` or `-if-not` that take a predicate rather than an element to match against:

--- a/docs/chapter3.md
+++ b/docs/chapter3.md
@@ -2336,7 +2336,7 @@ You will have to consult a reference to learn new `format` directives.
 
 ## 3.22 Answers
 
-**Answer 3.2** `(cons` *a b*) = (`list *` *a b*)
+**Answer 3.2** `(cons` *a b*) = (`list*` *a b*)
 
 **Answer 3.3**
 


### PR DESCRIPTION
Removed space from `: start` to make it `:start`.