### PR TITLE
fix package lock for CLISP

### DIFF
--- a/lisp/auxfns.lisp
+++ b/lisp/auxfns.lisp
@@ -13,6 +13,10 @@
   (dolist (pkg '(excl common-lisp common-lisp-user))
     (setf (excl:package-definition-lock (find-package pkg)) nil))
 
+  #+CLISP
+  (dolist (pkg '(common-lisp common-lisp-user))
+    (setf (package-lock (find-package pkg)) nil))
+
   ;; Don't warn if a function is defined in multiple files --
   ;; this happens often since we refine several programs.
   #+Lispworks


### PR DESCRIPTION
fixed as according to this clisp doc 

https://clisp.sourceforge.io/impnotes/pack-lock.html 

otherwise you get package locked errors when loading auxfns in clisp

tested with clisp, and also with sbcl to make sure it didn't break anything