### PR TITLE
Correct format string error in answer 3.12

### DIFF
--- a/docs/chapter3.md
+++ b/docs/chapter3.md
@@ -2455,7 +2455,7 @@ or, with an ANSI-compliant Common Lisp, you can specify a `:` key
   (reduce #'+ list :key #'(lambda (x) 1)))
 ```
 
-**Answer 3.12** `(format t "~@(~{~a~^ ~).~)" '(this is a test))`
+**Answer 3.12** `(format t "~@(~{~a~^ ~}.~)" '(this is a test))`
 
 ----------------------
 


### PR DESCRIPTION
Tested with sbcl. `~{` and `~}` starts and ends a loop.