### PR TITLE
Fix typo in chapter 4, block world domain

### DIFF
--- a/docs/chapter4.md
+++ b/docs/chapter4.md
@@ -1197,7 +1197,7 @@ That is, we could change `achieve-all` as follows:
       current-state)))
 
 (defun orderings (l)
-  (if (> (length l) l)
+  (if (> (length l) 1)
       (list l (reverse l))
       (list l)))
 ```


### PR DESCRIPTION
The logic here is only making orderings possible when the list has more than one elements.