### PR TITLE
Fix typos in chapter9.md

### DIFF
--- a/docs/chapter9.md
+++ b/docs/chapter9.md
@@ -422,8 +422,8 @@ Finally, if there are several elements in the right-hand side, they are each tur
  (let ((rhs (rule-rhs rule)))
    '(defun ,(rule-lhs rule) ()
     ,(cond ((every #'atom rhs) '(one-of ',rhs))
-       ((length =l rhs) (build-code (first rhs)))
-       (t '(case (random .(length rhs))
+       ((length=l rhs) (build-code (first rhs)))
+       (t '(case (random ,(length rhs))
          ,@(build-cases 0 rhs)))))))
 
 (defun build-cases (number choices)


### PR DESCRIPTION
Following function was transcribed wrongly

![image](https://github.com/norvig/paip-lisp/assets/9305875/0a789669-909a-4c6a-8539-44c59e597cd1)
