### PR TITLE
Correct answer for 22.8 to reflect original text

### DIFF
--- a/docs/chapter22.md
+++ b/docs/chapter22.md
@@ -1127,13 +1127,10 @@ Explain how this would be done both for the first version of the interpreter and
 **Answer 22.2** There is no way to implement a full `call/cc` to Common Lisp, but the following works for cases where the continuation is only used with dynamic extent:
 
 ```lisp
-(defun call/cc (cc computation)
-  "Make the continuation accessible to a Scheme procedure."
-  (funcall computation cc
-           ;; Package up CC into a Scheme function:
-           #'(lambda (cont val)
-               (declare (ignore cont))
-               (funcall cc val))))
+(defun call/cc (computation)
+  "Call the computation, passing it the current continuation.
+  The continuation has only dynamic extent."
+  (funcall computation #'(lambda (x) (return-from call/cc x))))
 ```
 
 **Answer 22.3** No.


### PR DESCRIPTION
The answer from 22.8 in the current version was mistakenly copied from the bottom of section 22.5, but that is the `call/cc` to implement the functionality in the scheme interpreter, not the limited version that would be used for partial functionality in Common Lisp. 

The original to answer 22.8:

![image](https://github.com/norvig/paip-lisp/assets/10394611/9e8c4e55-92e3-4ea6-ace0-d801e27b5f06)
