### PR TITLE
Update metadata.xml, changing dialect to American English

### DIFF
--- a/meta/metadata.xml
+++ b/meta/metadata.xml
@@ -1,5 +1,5 @@
 <dc:title>Paradigms of Artificial Intelligence Programming</dc:title>
-<dc:language>en-GB</dc:language>
+<dc:language>en-US</dc:language>
 <dc:creator opf:file-as="Norvig, Peter" opf:role="aut">Peter Norvig</dc:creator>
 <dc:publisher>norvig.com</dc:publisher>
 <dc:date opf:event="publication">2018-04-21</dc:date>


### PR DESCRIPTION
It was set to British English, likely due to copy-pasting an example.

@nuta caught this issue when I reused the epub generation elsewhere -  https://github.com/nuta/operating-system-in-1000-lines/pull/42