### PR TITLE
Replaced figures for Figure 16.1 and 17.5 with markdown tables

### DIFF
--- a/docs/chapter16.md
+++ b/docs/chapter16.md
@@ -78,12 +78,66 @@ After that we will return to the main core of EMYCIN, the backward-chaining rule
 Finally, we will show how to add some medical knowledge to EMYCIN to reconstruct MYCIN.
 A glossary of the program is in [figure  16.1](#f0010).
 
-| []()                                         |
-|----------------------------------------------|
-| ![f16-01](images/chapter16/f16-01.jpg)       |
-| Figure 16.1: Glossary for the EMYCIN Program |
 
-*(ed: this could be a markdown table)*
+| Function               | Description                                                         |
+|------------------------|---------------------------------------------------------------------|
+|                        | **Top-Level Functions for the Client**                              |
+| `emycin`               | Run the shell on a list of contexts representing a problem.         |
+| `mycin`                | Run the shell on the microbial infection domain.                    |
+|                        | **Top-Level Functions for the Expert**                              |
+| `defcontext`           | Define a context.                                                   |
+| `defparm`              | Define a parameter.                                                 |
+| `defrule`              | Define a rule.                                                      |
+|                        | **Constaints**                                                      |
+| `true`                 | A certainty factor of +1.                                           |
+| `false`                | A certainty factor of -1.                                           |
+| `unknown`              | A certainty factor of 0.                                            |
+| `cf-cut-off`           | Below this certainty we cut off search.                             |
+|                        | **Data Types**                                                      |
+| `context`              | A subdomain concerning a particular problem.                        |
+| `parm`                 | A parameter.                                                        |
+| `rule`                 | A backward-chainging rule with certainty factors.                   |
+| `yes/no`               | The type with members `yes` and `no`.                               |
+|                        | **Major Functions within Emycin**                                   |
+| `get-context-data`     | Collect data and draw conclusions.                                  |
+| `find-out`             | Determine values by knowing, asking, or using rules.                |
+| `get-db`               | Retrieve a fact from the data base.                                 |
+| `use-rules`            | Apply all rules relevent to a parameter.                            |
+| `use-rule`             | Applky one rule.                                                    |
+| `new-instance`         | Create a new instance of a context.                                 |
+| `report-findings`      | Print the results.                                                  |
+|                        | **Auxiliary Functions**                                             |
+| `cf-or`                | Combine certainty factors (CFs) with OR.                            |
+| `cf-and`               | Combine certainty factors (CFs) with AND.                           |
+| `true-p`               | Is this CF true for purposes of search?                             |
+| `false-p`              | Is this CF false for purposes of search?                            |
+| `cf-p`                 | Is this a certainty factor?                                         |
+| `put-db`               | Place a fact in the data base.                                      |
+| `clear-db`             | Clear all facts from the data base.                                 |
+| `get-vals`             | Get value and CF for a parameter/instance.                          |
+| `get-cf`               | Get CF for a parameter/instance/value triplet.                      |
+| `update-cf`            | Change CF for a parameter/instance/value triplet.                   |
+| `ask-vals`             | Ask the user for value/CF for a parameter/instance.                 |
+| `prompt-and-read-vals` | Print a prompt and read a reply.                                    |
+| `inst-name`            | The name of an instance.                                            |
+| `check-reply`          | See if reply is valid list of CF/values.                            |
+| `parse-reply`          | Convert reply into list of CF/values.                               |
+| `parm-type`            | Values of this parameter must be of this type.                      |
+| `get-parm`             | Find or make a parameter structure for this name.                   |
+| `put-rule`             | Add a new rule, indexed under each conclusion.                      |
+| `get-rules`            | Retrieve rules that help determine a parameter.                     |
+| `clear-rules`          | Remove all rules.                                                   |
+| `satisfy-premises`     | Calculate the combined CF for the premeises.                        |
+| `eval-condition`       | Determine the CF for a condition.                                   |
+| `reject-premise`       | Rule out a premise if it is clearly false.                          |
+| `conclude`             | Add a parameter/instance/value/CF to the data base.                 |
+| `is`                   | An alias for equal.                                                 |
+| `check-conditions`     | Make sure a rule is valid.                                          |
+| `print-rule`           | Print a rule.                                                       |
+| `print-conditions`     | Print a list of conditions.                                         |
+| `print-condition`      | Print a single condition.                                           |
+
+Figure 16.1: Glossary for the EMYCIN Program
 
 ## 16.1 Dealing with Uncertainty
 

--- a/docs/chapter17.md
+++ b/docs/chapter17.md
@@ -114,12 +114,6 @@ That completes the sketch of the line-labeling algorithm.
 We are now ready to implement a labeling program.
 Its glossary is in [figure 17.5](#fig-17-05).
 
-| []()                                                |
-|-----------------------------------------------------|
-| ![f17-05](images/chapter17/f17-05.jpg)              |
-| Figure 17.5: Glossary for the Line-Labeling Program |
-
-*(ed: should be a markdown table)*
 
 | Function                | Description                                                         |
 |-------------------------|---------------------------------------------------------------------|

--- a/docs/chapter17.md
+++ b/docs/chapter17.md
@@ -121,6 +121,39 @@ Its glossary is in [figure 17.5](#fig-17-05).
 
 *(ed: should be a markdown table)*
 
+| Function                | Description                                                         |
+|-------------------------|---------------------------------------------------------------------|
+|                         | **Top-Level Functions**                                             |
+| `print-labelings`       | Label the diagram by propagating constraints and then searching.    |
+|                         | **Data Types**                                                      |
+| `diagram`               | A diagram is a list of vertexes.                                    |
+| `vertex`                | A vertex has a name, type, and list of neighbors and labelings.     |
+|                         | **Major Functions**                                                 |
+| `find-labelings`        | Do the same constraint propagation, but don't print anything.       |
+| `propagate-constraints` | Reduce the number of labeling on vertex by considering neighbors.   |
+| `consistent-labelings`  | Return the set of labelings that are consistent with neighbors.|
+| `search-solutions`      | Try all labelings for one ambiguous vertex, and propagate.          |
+| `defdiagram`            | (macro) Define a diagram.                                           |
+| `diagram`               | Retrieve a diagram stored by name.                                  |
+| `ground`                | Attach the line between the two vertexes to the ground.             |
+|                         | **Auxiliary Functions**                                             |
+| `labels-for`            | Return all the labels for the line going to vertex.                 |
+| `reverse-label`         | Reverse left and right on arrow labels.                             |
+| `ambiguous-vertex-p`    | A vertex is ambiguous if it has more than one labeling.             |
+| `number-of-labelings`   | Number of labels on a vertex.                                       |
+| `find-vertex`           | Find the vertex with the given name.                                |
+| `matrix-transpose`      | Turn a matrix on its side.                                          |
+| `possible-labelings`    | The list of possible labelings fora given vertex type.              |
+| `print-vertex`          | Print a vertex in the short form.                                   |
+| `show-vertex`           | Print a vertex in a long form, on a new line.                       |
+| `show-diagram`          | Print a diagram in a long form. Include a title.                    |
+| `construct-diagram`     | Build a new diagram from a set of vertex descriptions.              |
+| `construct-vertex`      | Build a new vertex from a vertex description.                       |
+| `make-copy-diagram`     | Make a copy of a diagram, preserving connectivity.                  |
+| `check-diagram`         | Check if the description appears consistent.                        |
+
+Figure 17.5: Glossary for the Line-Labeling Program
+
 The two main data structures are the `diagram` and the `vertex`.
 It would have been possible to implement a data type for `lines`, but it is not necessary: lines are defined implicitly by the two vertexes at their end points.
 

--- a/docs/chapter18.md
+++ b/docs/chapter18.md
@@ -158,12 +158,58 @@ With this much decided, we are ready to begin.
 [Figure 18.3](#f0020) is the glossary for the complete program.
 A glossary for a second version of the program is on [page 623](#p623).
 
-| []()                                          |
-|-----------------------------------------------|
-| ![f18-03](images/chapter18/f18-03.jpg)        |
-| Figure 18.3: Glossary for the Othello Program |
+| Function                    | Description                                                         |
+|-----------------------------|---------------------------------------------------------------------|
+|                             | **Top-Level Function**                                              |
+| `othello`                   | Play a game of Othello. Return the score.                           |
+|                             | **Constants**                                                       |
+| `empty`                     | `0` represents an empty square.                                     |
+| `black`                     | `1` represents a black piece.                                       |
+| `white`                     | `2` represents a white piece.                                       |
+| `outer`                     | `3` represents a piece outside the 8 x 8 board.                     |
+| `all-directions`            | A list of integers representing the eight directions.               |
+| `all-squares`               | A list of all legal squares.                                        |
+| `winning-value`             | The best possible evaluation.                                       |
+| `losing-value`              | The worst possible evaluation.                                      |
+|                             | **Data Types**                                                      |
+| `piece`                     | An integer from `empty` to `outer`.                                 |
+| `board`                     | A vector of 100 pieces.                                             |
+|                             | **Major Functions**                                                 |
+| `get-move`                  | Call the player's strategy function to get a move.                  |
+| `make-move`                 | Update board to reflect move by player.                             |
+| `human`                     | A strategy that prompts a human player.                             |
+| `random-strategy`           | Make any legal move.                                                |
+| `maximize-difference`       | A strategy that maximizes the difference in pieces.                 |
+| `maximizer`                 | Return a strategy that maximizes some measure.                      |
+| `weighted-squares`          | Sum of the weights of player's squares minus opponent's.            |
+| `modified-weighted-squares` | Like above, but treating corners better.                            |
+| `minimax`                   | Find the best move according to `EVAL-FN`, searching `PLY` levels.  |
+| `minimax-searcher`          | Return a strategy that uses `minimax` to search.                    |
+| `alpha-beta`                | Find the best move according to `EVAL-FN`, searching `PLY` levels.  |
+| `alpha-beta-searcher`       | Return a strategy that uses `alpha-beta` to search.                 |
+|                             | **Auxiliary Functions**                                             |
+| `bref`                      | Reference to a position on the board.                               |
+| `copy-board`                | Make a new board.                                                   |
+| `initial-board`             | Return a board, empty except for the four pieces in the middle.     |
+| `print-board`               | Print a board, along with some statistics.                          |
+| `count-difference`          | Count player's pieces minus opponent's pieces.                      |
+| `name-of`                   | A character used to print a piece.                                  |
+| `opponent`                  | The opponent of `black` is `white`, and vice-versa.                 |
+| `valid-p`                   | A syntactically valid square.                                       |
+| `legal-p`                   | A legal move on the board.                                          |
+| `make-flips`                | Make any flips in the given direction.                              |
+| `would-flip?`               | Would this move result in any flips in this direction?              |
+| `find-bracketing-piece`     | Return the square number of the bracketing piece.                   |
+| `any-legal-move?`           | Does player have any legal moves in this position?                  |
+| `next-to-play`              | Compute the player to move next, or `NIL` if nobody can move.       |
+| `legal-moves`               | Returns a list of legal moves for player.                           |
+| `final-value`               | Is this a win, loss, or draw for player?                            |
+| `neighbors`                 | Return a list of all squares adjacent to a square.                  |
+| `switch-strategies`         | PLay one strategy for a while, then switch.                         |
+|                             | **Previously Defined Functions**                                    |
+| `random-elt`                | Choose a random element from a sequence. (pg. 36)                   |
 
-*(ed: this should be a markdown table)*
+Figure 18.3: Glossary for the Othello Program
 
 What follows is the code for directions and pieces.
 We explicitly define the type `piece` to be a number from `empty` to `outer` (0 to 3), and define the function `name-of` to map from a piece number to a character: a dot for empty, `@` for black, `0` for white, and a question mark (which should never be printed) for `outer`.
@@ -1055,12 +1101,42 @@ While we're at it, we'll also print the list of possible moves:
   (h8->88 (read)))
 ```
 
-| []()                                                        |
-|-------------------------------------------------------------|
-| ![f18-05](images/chapter18/f18-05.jpg)                      |
-| Figure 18.5: Glossary for the Tournament Version of Othello |
 
-*(ed: should be a markdown table)*
+| Function                | Description                                              |
+|-------------------------|----------------------------------------------------------|
+|                         | **Top-Level Functions**                                  |
+| `othello-series`        | Play a series of `N` games.                              |
+| `random-othello-series` | Play a series of games, starting from a random position. |
+| `round-robin`           | PLay a tournament among strategies.                      |
+|                         | **Special Variables**                                    |
+| `*clock*`               | A copy of the game clock (tournament version only).      |
+| `*board*`               | A copy of the game board (tournament version only).      |
+| `*move-number*`         | Number of moves made (tournament version only).          |
+| `*ply-boards*`          | A vector of boards; used as a resource to avoid consing. |
+|                         | **Data Structures**                                      |
+| `node`                  | Holds a board and its evaluation.                        |
+|                         | **Main Functions**                                       |
+| `alpha-beta2`           | Sorts moves by static evaluation.                        |
+| `alpha-beta-searcher2`  | Strategy using `alpha-beta2`.                            |
+| `alpha-beta3`           | Uses the `killer` heuristic.                             |
+| `alpha-beta-searcher3`  | Strategy using `alpha-beta3`.                            |
+| `Iago-eval`             | Evaluation function based on Rosenbloom's program.       |
+| `Iago`                  | Strategy using `Iago-eval`.                              |
+|                         | **Auxiliary Functions**                                  |
+| `h8->88`                | Convert from alphanumeric to numeric square notation.    |
+| `88->h8`                | Convert from numeric to alphanumeric square notation.    |
+| `time-string`           | Convert internal time units to a `mm:ss` string          |
+| `switch-strategies`     | Play one strategy for a while, then another.             |
+| `mobility`              | A strategy that counts the number of legal moves.        |
+| `legal-nodes`           | A list of legal moves sorted by their evaluation.        |
+| `negate-node`           | Set the value of a node to its negative.                 |
+| `put-first`             | Put the `killer` move first, if it is legal.             |
+|                         | **Previously Defined Functions**                         |
+| `cross-product`         | Apply `fn` to all pairs of arguements. (pg. 47)          |
+| `symbol`                | Build a symbol by concatenting components.               |
+
+
+Figure 18.5: Glossary for the Tournament Version of Othello
 
 The `othello` function needn't worry about notation, but it does need to monitor the time.
 We make up a new data structure, the clock, which is an array of integers saying how much time (in internal units) each player has left.

--- a/docs/chapter21.md
+++ b/docs/chapter21.md
@@ -24,12 +24,41 @@ All single-letter arguments denote metavariables; for example, each noun phrase 
 Similarly, the `hin modifiers` is a variable that refers to the head-the thing that is being modified.
 The other arguments and categories will be explained in turn, but it is handy to have this figure to refer back to.
 
-| []()                                                    |
-|---------------------------------------------------------|
-| ![f21-01](images/chapter21/f21-01.jpg)                  |
-| Figure 21.1: Grammatical Categories and their Arguments |
 
-*(ed: should be a markdown table)*
+| Category      | Arguments                                  |
+|---------------|--------------------------------------------|
+|               | **Preterminals**                           |
+|  `name`       | `agr name`                                 |
+|  `verb`       | `verb inflection slots v sem`              |
+|  `rel-pro`    | `case type`                                |
+|  `pronoun`    | `arg case wh x sem`                        |
+|  `art`        | `agr quant`                                |
+|  `adj`        | `x sem`                                    |
+|  `cardinal`   | `number agr`                               |
+|  `ordinal`    | `number`                                   |
+|  `prep`       | `prep sem`                                 |
+|  `noun`       | `agr slots x sem`                          |
+|  `aux`        | `inflection needs-inflection v sem`        |
+|  `adverb`     | `x sem`                                    |
+|               |  **Nonterminals**                          |
+|  `S`          | `s sem`                                    |
+|  `aux-inv-S`  | `subject s sem`                            |
+|  `clause`     | `inflection x int-subj v gapl gap2 sem`    |
+|  `subject`    | `agr x subj-slot int-subj gap1 gap2 sem`   |
+|  `VP`         | `inflection x subject-slot v gap1 gap2 vp` |
+|  `NP`         | `agr case wh x gap1 gap2 np`               |
+|  `NP2`        | `agr case x gap1 gap2 sem`                 |
+|  `PP`         | `prep role wh np x gap1 gap2 sem`          |
+|  `XP`         | `slot constituent wh x gap1 gap2 sem`      |
+|  `Det`        | `agr wh x restriction sem`                 |
+|  `rel-clause` | `agr x sem`                                |
+|  `modifiers`  | `pre/post cat info slots h gap1 gap2 sem`  |
+|  `complement` | `cat info slot h gap1 gap2 sem`            |
+|  `adjunct`    | `pre/post cat info h gap1 gap2 sem`        |
+|  `advp`       | `wh x gap1 gap2 sem`                       |
+
+
+Figure 21.1: Grammatical Categories and their Arguments
 
 ## 21.1 Noun Phrases
 


### PR DESCRIPTION
Replaced Figure 16.1:  Glossary for the EMYCIN Program and Figure 17.5 Glossary for the Line-Labeling Program with markdown versions of the tables in the jpg images